### PR TITLE
feat: Google OAuth/OIDC 로그인 시작 API 구현 (AUTH-001)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// TSID
+	implementation 'com.github.f4b6a3:tsid-creator:5.2.6'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/env.example
+++ b/env.example
@@ -1,3 +1,6 @@
 DB_NAME=db_name
 DB_ROOT_PASSWORD=mysql_root_password
 JWT_SECRET=base64_encoded_jwt_secret
+
+GOOGLE_CLIENT_ID=google_client_id
+GOOGLE_CLIENT_SECRET=google_client_secret

--- a/src/main/java/com/hogu/am_i_hogu/AmIHoguApplication.java
+++ b/src/main/java/com/hogu/am_i_hogu/AmIHoguApplication.java
@@ -3,9 +3,10 @@ package com.hogu.am_i_hogu;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
-// JWT/OAuth 기반의 인증만 사용하므로 기본 사용자 자동 생성 비활성화
-@SpringBootApplication(exclude = UserDetailsServiceAutoConfiguration.class)
+@ConfigurationPropertiesScan													// config 클래스 탐색
+@SpringBootApplication(exclude = UserDetailsServiceAutoConfiguration.class)		// JWT/OAuth 기반의 인증만 사용하므로 기본 사용자 자동 생성 비활성화
 public class AmIHoguApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hogu/am_i_hogu/common/util/TsidGenerator.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/util/TsidGenerator.java
@@ -1,0 +1,12 @@
+package com.hogu.am_i_hogu.common.util;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TsidGenerator {
+
+	public long nextId() {
+		return TsidCreator.getTsid().toLong();
+	}
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/config/GoogleOAuthProperties.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/config/GoogleOAuthProperties.java
@@ -1,0 +1,19 @@
+package com.hogu.am_i_hogu.domain.oauth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * application.yml에 정의된 google OAuth 설정값을 바인딩하는 설정 클래스
+ */
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "oauth.google")
+public class GoogleOAuthProperties {
+    private String clientId;            // google 측에서 발급받은 client id
+    private String clientSecret;        // google 측에서 발급받은 client secret
+    private String redirectUri;         // google 로그인 인증 완료 후 인가 코드를 전달받을 callback URL
+    private String authorizationUri;    // google 로그인 페이지로 이동시키기 위한 google 인증 서버의 endpoint URL
+    private String scope;               // 유저에게 권한을 요구할 정보의 범위
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthController.java
@@ -1,0 +1,37 @@
+package com.hogu.am_i_hogu.domain.oauth.controller;
+
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import com.hogu.am_i_hogu.domain.oauth.service.OAuthService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+public class OAuthController {
+
+    private final OAuthService oauthService;
+
+    public OAuthController(OAuthService oauthService) {
+        this.oauthService = oauthService;
+    }
+
+    /**
+     * [AUTH-001] 소셜 로그인 연동 페이지로 redirect
+     *
+     * @param provider path variable으로 전달받은 소셜 로그인 provider
+     * @return '302 Found + Location 헤더의 Authorization URL' 반환
+     */
+    @GetMapping("/api/auth/login/{provider}")
+    public ResponseEntity<Void> redirectToProviderLogin(@PathVariable String provider) {
+        OAuthProvider oauthProvider = OAuthProvider.from(provider);
+
+        String authorizationUrl = oauthService.getAuthorizationUrl(oauthProvider);
+
+        return ResponseEntity.status(302)
+                .location(URI.create(authorizationUrl))
+                .build();
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
@@ -15,7 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access= AccessLevel.PROTECTED)
 @Table(name="oauth_login_states")
 public class OAuthLoginState {
-    private static final long EXPIRES_IN_MINUTES = 5;       // TODO: state 만료 시간 논의 필요
+    private static final long EXPIRES_IN_MINUTES = 5;
     @Id
     private Long id;
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
@@ -1,0 +1,54 @@
+package com.hogu.am_i_hogu.domain.oauth.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * OAuth 로그인 과정에서 발급한 state, nonce 값을 저장하기 위한 엔티티
+ */
+@Getter
+@Entity
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@Table(name="oauth_login_states")
+public class OAuthLoginState {
+    private static final long EXPIRES_IN_MINUTES = 5;       // TODO: state 만료 시간 논의 필요
+    @Id
+    private Long id;                                        // TODO: 공통 ID 생성 전략 적용 필요
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private OAuthProvider provider;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String state;
+
+    @Column(nullable = false, length = 64, unique = true)
+    private String nonce;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    private LocalDateTime consumedAt;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public OAuthLoginState(
+            Long id,
+            OAuthProvider provider,
+            String state,
+            String nonce,
+            LocalDateTime createdAt
+    ) {
+        this.id = id;
+        this.provider = provider;
+        this.state = state;
+        this.nonce = nonce;
+        this.createdAt = createdAt;
+        this.expiresAt = createdAt.plusMinutes(EXPIRES_IN_MINUTES);
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthLoginState.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 public class OAuthLoginState {
     private static final long EXPIRES_IN_MINUTES = 5;       // TODO: state 만료 시간 논의 필요
     @Id
-    private Long id;                                        // TODO: 공통 ID 생성 전략 적용 필요
+    private Long id;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 16)

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
@@ -1,5 +1,8 @@
 package com.hogu.am_i_hogu.domain.oauth.domain;
 
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.oauth.exception.OAuthErrorCode;
+
 public enum OAuthProvider {
     GOOGLE;
 
@@ -9,14 +12,13 @@ public enum OAuthProvider {
      *
      * @param providerName 변환할 소셜 로그인 provider 이름
      * @return 매칭되는 OAuthProvider Enum 상수
-     * @throws IllegalArgumentException 지원하지 않는 제공자 이름이 입력된 경우 발생
+     * @throws CustomException 지원하지 않는 제공자 이름이 입력된 경우 발생
      */
     public static OAuthProvider from(String providerName) {
         return switch(providerName) {
             case "GOOGLE" -> GOOGLE;
 
-            // HACK: custom exception 구현 전 임시로 IllegalArgumentException 사용
-            default -> throw new IllegalArgumentException("Unsupported provider: " + providerName);
+            default -> throw new CustomException(OAuthErrorCode.UNSUPPORTED_PROVIDER);
         };
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
@@ -1,0 +1,22 @@
+package com.hogu.am_i_hogu.domain.oauth.domain;
+
+public enum OAuthProvider {
+    GOOGLE;
+
+    /**
+     * 문자열 형태의 provider 이름을 Enum 객체로 변환
+     * 지원하지 않는 provider일 경우 exception throw
+     *
+     * @param providerName 변환할 소셜 로그인 provider 이름
+     * @return 매칭되는 OAuthProvider Enum 상수
+     * @throws IllegalArgumentException 지원하지 않는 제공자 이름이 입력된 경우 발생
+     */
+    public static OAuthProvider from(String providerName) {
+        return switch(providerName) {
+            case "GOOGLE" -> GOOGLE;
+
+            // HACK: custom exception 구현 전 임시로 IllegalArgumentException 사용
+            default -> throw new IllegalArgumentException("Unsupported provider: " + providerName);
+        };
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/exception/OAuthErrorCode.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/exception/OAuthErrorCode.java
@@ -1,0 +1,18 @@
+package com.hogu.am_i_hogu.domain.oauth.exception;
+
+import com.hogu.am_i_hogu.common.exception.ErrorCodeType;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum OAuthErrorCode implements ErrorCodeType {
+    UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "UNSUPPORTED_PROVIDER");
+
+    private final HttpStatus status;
+    private final String code;
+
+    OAuthErrorCode(HttpStatus status, String code) {
+        this.status = status;
+        this.code = code;
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/repository/OAuthLoginStateRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/repository/OAuthLoginStateRepository.java
@@ -1,0 +1,13 @@
+package com.hogu.am_i_hogu.domain.oauth.repository;
+
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * OAuth 로그인 과정에서 발생하는 상태값의 영속성 관리
+ * 인가 요청 전 DB에 상태 저장을 위해 사용
+ */
+@Repository
+public interface OAuthLoginStateRepository extends JpaRepository<OAuthLoginState, Long> {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/service/OAuthService.java
@@ -1,0 +1,103 @@
+package com.hogu.am_i_hogu.domain.oauth.service;
+
+import com.hogu.am_i_hogu.domain.oauth.config.GoogleOAuthProperties;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import com.hogu.am_i_hogu.domain.oauth.repository.OAuthLoginStateRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+
+@Service
+public class OAuthService {
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    private final GoogleOAuthProperties googleOAuthProperties;
+    private final OAuthLoginStateRepository oauthLoginStateRepository;
+
+    public OAuthService(
+            GoogleOAuthProperties googleOAuthProperties,
+            OAuthLoginStateRepository oauthLoginStateRepository) {
+        this.googleOAuthProperties = googleOAuthProperties;
+        this.oauthLoginStateRepository = oauthLoginStateRepository;
+    }
+
+    /**
+     * 지정된 OAuth provider의 로그인 페이지 URL 생성하여 반환
+     * state, nonce 생성 및 DB 기록
+     *
+     * @param provider 요청할 소셜 로그인 제공자
+     * @return 사용자를 리다이렉트 시킬 로그인 페이지의 URL 문자열
+     */
+    public String getAuthorizationUrl(OAuthProvider provider) {
+        return switch (provider) {
+            case GOOGLE -> buildGoogleAuthorizationUrl();
+        };
+    }
+
+    /**
+     * google 소셜 로그인을 위한 authorization URL 생성
+     * state, nonce 값을 생성하여 DB에 저장 후 URL에 포함
+     *
+     * @return 사용자를 redirect 시킬 google 로그인 페이지 URL
+     */
+    private String buildGoogleAuthorizationUrl() {
+        String state = generateRandomValue();
+        String nonce = generateRandomValue();
+        saveOAuthLoginState(OAuthProvider.GOOGLE, state, nonce);
+
+        return UriComponentsBuilder
+                .fromUriString(googleOAuthProperties.getAuthorizationUri())
+                .queryParam("client_id", googleOAuthProperties.getClientId())
+                .queryParam("response_type", "code")
+                .queryParam("scope", googleOAuthProperties.getScope())
+                .queryParam("redirect_uri", googleOAuthProperties.getRedirectUri())
+                .queryParam("state", state)
+                .queryParam("nonce", nonce)
+                .build()
+                .toUriString();
+    }
+
+    /**
+     * state, nonce 값 생성을 위한 난수 생성기
+     *
+     * @return URL-Safe 32byte 난수 문자열
+     */
+    private String generateRandomValue() {
+        byte[] randomBytes = new byte[32];
+        secureRandom.nextBytes(randomBytes);
+
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(randomBytes);
+    }
+
+    /**
+     * OAuthLoginState를 생성해 DB에 저장
+     *
+     * @param provider  소셜로그인 provider
+     * @param state     CSRF 공격 방어를 위한 상태값
+     * @param nonce     ID token 무결성 검증을 위한 난수값
+     */
+    private void saveOAuthLoginState(
+            OAuthProvider provider,
+            String state,
+            String nonce
+    ) {
+        // HACK: 공통 ID 생성 전략 적용 전 임시 ID 생성
+        long tempId = System.currentTimeMillis();
+
+        OAuthLoginState oauthLoginState = new OAuthLoginState(
+                tempId,
+                provider,
+                state,
+                nonce,
+                LocalDateTime.now()
+        );
+
+        oauthLoginStateRepository.save(oauthLoginState);
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/service/OAuthService.java
@@ -1,5 +1,6 @@
 package com.hogu.am_i_hogu.domain.oauth.service;
 
+import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.oauth.config.GoogleOAuthProperties;
 import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
 import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
@@ -17,12 +18,15 @@ public class OAuthService {
 
     private final GoogleOAuthProperties googleOAuthProperties;
     private final OAuthLoginStateRepository oauthLoginStateRepository;
+    private final TsidGenerator tsidGenerator;
 
     public OAuthService(
             GoogleOAuthProperties googleOAuthProperties,
-            OAuthLoginStateRepository oauthLoginStateRepository) {
+            OAuthLoginStateRepository oauthLoginStateRepository,
+            TsidGenerator tsidGenerator) {
         this.googleOAuthProperties = googleOAuthProperties;
         this.oauthLoginStateRepository = oauthLoginStateRepository;
+        this.tsidGenerator = tsidGenerator;
     }
 
     /**
@@ -87,11 +91,10 @@ public class OAuthService {
             String state,
             String nonce
     ) {
-        // HACK: 공통 ID 생성 전략 적용 전 임시 ID 생성
-        long tempId = System.currentTimeMillis();
+        long id = tsidGenerator.nextId();
 
         OAuthLoginState oauthLoginState = new OAuthLoginState(
-                tempId,
+                id,
                 provider,
                 state,
                 nonce,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,15 @@ jwt:
   # jwt secret key
   secret: ${JWT_SECRET}
 
+oauth:
+  # google 소셜 로그인 정보
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: http://localhost:8080/api/auth/callback/GOOGLE
+    authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+    scope: openid
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/test/java/com/hogu/am_i_hogu/common/util/TsidGeneratorTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/util/TsidGeneratorTest.java
@@ -1,0 +1,24 @@
+package com.hogu.am_i_hogu.common.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class TsidGeneratorTest {
+
+	@Test
+	void nextId_returnsUniquePositiveLongIds() {
+		TsidGenerator generator = new TsidGenerator();
+		Set<Long> ids = new HashSet<>();
+
+		for (int i = 0; i < 1_000; i++) {
+			long id = generator.nextId();
+
+			assertThat(id).isPositive();
+			assertThat(ids.add(id)).isTrue();
+		}
+	}
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.hogu.am_i_hogu.domain.oauth;
 
+import com.hogu.am_i_hogu.common.security.JwtAccessDeniedHandler;
 import com.hogu.am_i_hogu.common.security.JwtAuthenticationEntryPoint;
 import com.hogu.am_i_hogu.common.security.JwtProvider;
 import com.hogu.am_i_hogu.common.security.SecurityConfig;
@@ -29,6 +30,9 @@ public class OAuthControllerTest {
 
     @MockitoBean
     private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @MockitoBean
     private OAuthService oauthService;

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
@@ -33,6 +33,13 @@ public class OAuthControllerTest {
     @MockitoBean
     private OAuthService oauthService;
 
+    /**
+     * 지원하는 provider로 로그인 요청 시 OAuth provider 로그인 페이지로 redirect 되는지 테스트:
+     * - access token 없이 GOOGLE 로그인 요청을 보내고,
+     * - (1) 응답 status가 302 Found인지 확인
+     * - (2) Location 헤더가 OAuthService가 반환한 URL과 같은지 확인
+     * - (3) OAuthService가 GOOGLE provider로 호출되었는지 확인
+     */
     @Test
     void redirectProviderLoginTest() throws Exception {
         when(jwtProvider.validateAccessToken(null))
@@ -50,6 +57,12 @@ public class OAuthControllerTest {
         verify(oauthService).getAuthorizationUrl(OAuthProvider.GOOGLE);
     }
 
+    /**
+     * 지원하지 않는 provider로 로그인 요청 시 400 Bad Request와 오류 응답을 반환하는지 테스트:
+     * - access token 없이 지원하지 않는 provider로 로그인 요청을 보내고,
+     * - (1) 응답 status가 400 Bad Request인지 확인
+     * - (2) 응답 본문이 UNSUPPORTED_PROVIDER 오류 코드를 반환하는지 확인
+     */
     @Test
     void redirectUnsupportedProviderTest() throws Exception {
         when(jwtProvider.validateAccessToken(null))

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthControllerTest.java
@@ -1,0 +1,62 @@
+package com.hogu.am_i_hogu.domain.oauth;
+
+import com.hogu.am_i_hogu.common.security.JwtAuthenticationEntryPoint;
+import com.hogu.am_i_hogu.common.security.JwtProvider;
+import com.hogu.am_i_hogu.common.security.SecurityConfig;
+import com.hogu.am_i_hogu.domain.oauth.controller.OAuthController;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import com.hogu.am_i_hogu.domain.oauth.service.OAuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(OAuthController.class)
+@Import(SecurityConfig.class)
+public class OAuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @MockitoBean
+    private OAuthService oauthService;
+
+    @Test
+    void redirectProviderLoginTest() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        when(oauthService.getAuthorizationUrl(OAuthProvider.GOOGLE))
+                .thenReturn("https://accounts.google.com/o/oauth2/v2/auth?client_id=test-client-id");
+
+        mockMvc.perform(get("/api/auth/login/GOOGLE"))
+                .andExpect(status().isFound())
+                .andExpect(header().string(
+                        "Location",
+                        "https://accounts.google.com/o/oauth2/v2/auth?client_id=test-client-id"
+                ));
+
+        verify(oauthService).getAuthorizationUrl(OAuthProvider.GOOGLE);
+    }
+
+    @Test
+    void redirectUnsupportedProviderTest() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+
+        mockMvc.perform(get("/api/auth/login/INVALID_PROVIDER"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string("{\"code\":\"UNSUPPORTED_PROVIDER\"}"));
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthLoginStateTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthLoginStateTest.java
@@ -10,6 +10,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class OAuthLoginStateTest {
 
+    /**
+     * OAuthLoginState 생성 테스트:
+     * - id, provider, state, nonce, createdAt 값을 주어 객체를 생성하고,
+     * - (1) 각 필드가 전달한 값과 같은지 확인
+     * - (2) expiresAt이 createdAt 기준 5분 뒤로 설정되는지 확인
+     * - (3) consumedAt이 null로 초기화되는지 확인
+     */
     @Test
     void createOAuthLoginStateTest() {
         String state = "this-is-state-value";

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthLoginStateTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthLoginStateTest.java
@@ -1,0 +1,33 @@
+package com.hogu.am_i_hogu.domain.oauth;
+
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class OAuthLoginStateTest {
+
+    @Test
+    void createOAuthLoginStateTest() {
+        String state = "this-is-state-value";
+        String nonce = "this-is-nonce-value";
+        LocalDateTime createdAt = LocalDateTime.now();
+        OAuthLoginState oauthLoginState =
+                new OAuthLoginState(1L,
+                        OAuthProvider.GOOGLE,
+                        state,
+                        nonce,
+                        createdAt);
+
+        assertThat(oauthLoginState.getId()).isEqualTo(1L);
+        assertThat(oauthLoginState.getProvider()).isEqualTo(OAuthProvider.GOOGLE);
+        assertThat(oauthLoginState.getState()).isEqualTo(state);
+        assertThat(oauthLoginState.getNonce()).isEqualTo(nonce);
+        assertThat(oauthLoginState.getCreatedAt()).isEqualTo(createdAt);
+        assertThat(oauthLoginState.getExpiresAt()).isEqualTo(createdAt.plusMinutes(5));
+        assertThat(oauthLoginState.getConsumedAt()).isNull();
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthProviderTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthProviderTest.java
@@ -10,6 +10,11 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class OAuthProviderTest {
 
+    /**
+     * 유효한 provider 값 검증 테스트:
+     * 지원하는 provider 이름이 주어졌을 때
+     * 올바른 OAuthProvider Enum 상수로 변환되는지 테스트
+     */
     @Test
     void fromSupportedProviderTest() {
         OAuthProvider provider = OAuthProvider.from("GOOGLE");
@@ -17,6 +22,11 @@ public class OAuthProviderTest {
         assertThat(provider).isEqualTo(OAuthProvider.GOOGLE);
     }
 
+    /**
+     * 유효하지 않은 provider 값 검증 테스트:
+     * 지원하지 않는 provider 이름이 주어졌을 때
+     * UNSUPPORTED_PROVIDER 예외가 발생하는지 테스트
+     */
     @Test
     void fromUnsupportedProviderTest() {
         assertThatThrownBy(()->OAuthProvider.from("INVALID_PROVIDER"))

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthProviderTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthProviderTest.java
@@ -1,0 +1,28 @@
+package com.hogu.am_i_hogu.domain.oauth;
+
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import com.hogu.am_i_hogu.domain.oauth.exception.OAuthErrorCode;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+public class OAuthProviderTest {
+
+    @Test
+    void fromSupportedProviderTest() {
+        OAuthProvider provider = OAuthProvider.from("GOOGLE");
+
+        assertThat(provider).isEqualTo(OAuthProvider.GOOGLE);
+    }
+
+    @Test
+    void fromUnsupportedProviderTest() {
+        assertThatThrownBy(()->OAuthProvider.from("INVALID_PROVIDER"))
+                .isInstanceOfSatisfying(CustomException.class, exception -> {
+                    assertThat(exception.getErrorCode())
+                            .isEqualTo(OAuthErrorCode.UNSUPPORTED_PROVIDER);
+                });
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
@@ -1,5 +1,6 @@
 package com.hogu.am_i_hogu.domain.oauth;
 
+import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.oauth.config.GoogleOAuthProperties;
 import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
 import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
@@ -19,8 +20,9 @@ public class OAuthServiceTest {
 
     private final GoogleOAuthProperties googleOAuthProperties = mock(GoogleOAuthProperties.class);
     private final OAuthLoginStateRepository oauthLoginStateRepository = mock(OAuthLoginStateRepository.class);
+    private final TsidGenerator tsidGenerator = mock(TsidGenerator.class);
     private final OAuthService oauthService =
-            new OAuthService(googleOAuthProperties, oauthLoginStateRepository);
+            new OAuthService(googleOAuthProperties, oauthLoginStateRepository, tsidGenerator);
 
     @Test
     void getAuthorizationUrlTest() {
@@ -32,11 +34,14 @@ public class OAuthServiceTest {
                 .thenReturn("http://localhost:8080/api/auth/callback/GOOGLE");
         when(googleOAuthProperties.getScope())
                 .thenReturn("openid");
+        when(tsidGenerator.nextId())
+                .thenReturn(1L);
 
         String authorizationUrl = oauthService.getAuthorizationUrl(OAuthProvider.GOOGLE);
 
         ArgumentCaptor<OAuthLoginState> captor = ArgumentCaptor.forClass(OAuthLoginState.class);
         verify(oauthLoginStateRepository).save(captor.capture());
+        verify(tsidGenerator).nextId();
         OAuthLoginState savedState = captor.getValue();
 
         Map<String, List<String>> params = UriComponentsBuilder
@@ -44,6 +49,7 @@ public class OAuthServiceTest {
                 .build()
                 .getQueryParams();
 
+        assertThat(savedState.getId()).isEqualTo(1L);
         assertThat(authorizationUrl).isNotBlank();
         assertThat(params.get("client_id").get(0)).isEqualTo("test-client-id");
         assertThat(params.get("response_type").get(0)).isEqualTo("code");

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
@@ -24,6 +24,15 @@ public class OAuthServiceTest {
     private final OAuthService oauthService =
             new OAuthService(googleOAuthProperties, oauthLoginStateRepository, tsidGenerator);
 
+    /**
+     * google authorization URL 생성 테스트:
+     * - google OAuth 설정값과 tsid 값을 준비하고,
+     * - (1) OAuthLoginState가 저장되는지 확인
+     * - (2) tsidGenerator를 사용해 id를 생성하는지 확인
+     * - (3) 저장된 OAuthLoginState의 id가 생성한 tsid와 같은지 확인
+     * - (4) authorization URL의 고정 query parameter가 올바른지 확인
+     * - (5) authorization URL의 state, nonce가 저장된 값과 같은지 확인
+     */
     @Test
     void getAuthorizationUrlTest() {
         when(googleOAuthProperties.getAuthorizationUri())

--- a/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/oauth/OAuthServiceTest.java
@@ -1,0 +1,55 @@
+package com.hogu.am_i_hogu.domain.oauth;
+
+import com.hogu.am_i_hogu.domain.oauth.config.GoogleOAuthProperties;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthLoginState;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import com.hogu.am_i_hogu.domain.oauth.repository.OAuthLoginStateRepository;
+import com.hogu.am_i_hogu.domain.oauth.service.OAuthService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.*;
+
+public class OAuthServiceTest {
+
+    private final GoogleOAuthProperties googleOAuthProperties = mock(GoogleOAuthProperties.class);
+    private final OAuthLoginStateRepository oauthLoginStateRepository = mock(OAuthLoginStateRepository.class);
+    private final OAuthService oauthService =
+            new OAuthService(googleOAuthProperties, oauthLoginStateRepository);
+
+    @Test
+    void getAuthorizationUrlTest() {
+        when(googleOAuthProperties.getAuthorizationUri())
+                .thenReturn("https://accounts.google.com/o/oauth2/v2/auth");
+        when(googleOAuthProperties.getClientId())
+                .thenReturn("test-client-id");
+        when(googleOAuthProperties.getRedirectUri())
+                .thenReturn("http://localhost:8080/api/auth/callback/GOOGLE");
+        when(googleOAuthProperties.getScope())
+                .thenReturn("openid");
+
+        String authorizationUrl = oauthService.getAuthorizationUrl(OAuthProvider.GOOGLE);
+
+        ArgumentCaptor<OAuthLoginState> captor = ArgumentCaptor.forClass(OAuthLoginState.class);
+        verify(oauthLoginStateRepository).save(captor.capture());
+        OAuthLoginState savedState = captor.getValue();
+
+        Map<String, List<String>> params = UriComponentsBuilder
+                .fromUriString(authorizationUrl)
+                .build()
+                .getQueryParams();
+
+        assertThat(authorizationUrl).isNotBlank();
+        assertThat(params.get("client_id").get(0)).isEqualTo("test-client-id");
+        assertThat(params.get("response_type").get(0)).isEqualTo("code");
+        assertThat(params.get("scope").get(0)).isEqualTo("openid");
+        assertThat(params.get("redirect_uri").get(0)).isEqualTo("http://localhost:8080/api/auth/callback/GOOGLE");
+        assertThat(params.get("state").get(0)).isEqualTo(savedState.getState());
+        assertThat(params.get("nonce").get(0)).isEqualTo(savedState.getNonce());
+    }
+}


### PR DESCRIPTION
## 📋 변경 사항

Google 로그인 시작 API 구현 (AUTH-001)
- Google 로그인 요청 시 이동할 endpoint 추가
- Google OAuth authorization URL 생성 로직 구현
- 로그인 시작 시 `state`, `nonce` 생성 로직 추가
- `oauth_login_states` 저장 구조 추가
- Google OAuth 설정값 바인딩용 properties 클래스 추가
- OAuth provider 관련 예외 코드 및 provider 변환 로직 추가
- OAuth domain/service/controller 테스트 작성

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

- `OAuthControllerTest`
    - 지원하는 provider 요청 시 Google 로그인 URL로 redirect 응답 보내는지 확인
    - 지원하지 않는 provider 요청 시 적절한 오류 응답 반환 확인
- `OAuthServiceTest`
    - authorization URL에 적절한 query parameter 포함되는지 확인
- `OAuthLoginStateTest`
    - 로그인 관련 상태 값 객체가 적절히 생성되어 저장되는지 확인
- `OAuthProviderTest`
    - 요청으로 들어온 provider 값 검증이 제대로 이루어지는지 확인

- `GET /api/auth/login/GOOGLE` 호출 시, Google 로그인 화면으로 정상 redirect 됨을 확인

## 🔗 관련 이슈

- Closes #11 
