### PR TITLE
feat: 게시물 북마크 등록/ 취소 api 구현

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
@@ -2,9 +2,11 @@ package com.hogu.am_i_hogu.domain.post.controller;
 
 import com.hogu.am_i_hogu.domain.post.dto.request.PostCreateRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostUpdateRequest;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostBookmarkResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostCreateResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostUpdateResponse;
+import com.hogu.am_i_hogu.domain.post.service.PostBookmarkService;
 import com.hogu.am_i_hogu.domain.post.service.PostCreateService;
 import com.hogu.am_i_hogu.domain.post.service.PostDeleteService;
 import com.hogu.am_i_hogu.domain.post.service.PostDetailService;
@@ -23,6 +25,7 @@ public class PostController {
     private final PostDetailService postDetailService;
     private final PostUpdateService postUpdateService;
     private final PostDeleteService postDeleteService;
+    private final PostBookmarkService postBookmarkService;
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId, Authentication authentication) {
@@ -63,5 +66,27 @@ public class PostController {
         postDeleteService.delete(postId, userId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{postId}/bookmarks")
+    public ResponseEntity<PostBookmarkResponse> createBookmark(
+            @PathVariable Long postId,
+            Authentication authentication
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+        PostBookmarkResponse response = postBookmarkService.create(userId, postId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{postId}/bookmarks")
+    public ResponseEntity<PostBookmarkResponse> deleteBookmark(
+            @PathVariable Long postId,
+            Authentication authentication
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+        PostBookmarkResponse response = postBookmarkService.delete(userId, postId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostBookmark.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostBookmark.java
@@ -1,0 +1,29 @@
+package com.hogu.am_i_hogu.domain.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post_bookmarks")
+public class PostBookmark {
+
+    @EmbeddedId
+    private PostBookmarkId id;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    public PostBookmark(PostBookmarkId id, LocalDateTime createdAt) {
+        this.id = id;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostBookmarkId.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostBookmarkId.java
@@ -1,0 +1,25 @@
+package com.hogu.am_i_hogu.domain.post.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostBookmarkId implements Serializable {
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "post_id")
+    private Long postId;
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
@@ -1,0 +1,4 @@
+package com.hogu.am_i_hogu.domain.post.dto.response;
+
+public record PostBookmarkResponse(boolean isBookmarked) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
@@ -10,7 +10,8 @@ public enum PostErrorCode implements ErrorCodeType {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE"),
     WRONG_POSTID_TYPE(HttpStatus.BAD_REQUEST, "WRONG_POSTID_TYPE"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND"),
-    POST_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POST_ALREADY_DELETED");
+    POST_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POST_ALREADY_DELETED"),
+    DUPLICATE_REQUEST(HttpStatus.CONFLICT, "DUPLICATE_REQUEST");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostBookmarkRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostBookmarkRepository.java
@@ -1,0 +1,10 @@
+package com.hogu.am_i_hogu.domain.post.repository;
+
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmark;
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmarkId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostBookmarkRepository extends JpaRepository<PostBookmark, PostBookmarkId> {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkService.java
@@ -1,0 +1,57 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.post.domain.Post;
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmark;
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmarkId;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostBookmarkResponse;
+import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;
+import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PostBookmarkService {
+
+    private final PostRepository postRepository;
+    private final PostBookmarkRepository postBookmarkRepository;
+
+    @Transactional
+    public PostBookmarkResponse create(Long userId, Long postId) {
+        validateBookmarkablePost(postId);
+
+        PostBookmarkId id = new PostBookmarkId(userId, postId);
+        if (postBookmarkRepository.existsById(id)) {
+            throw new CustomException(PostErrorCode.DUPLICATE_REQUEST);
+        }
+
+        postBookmarkRepository.save(new PostBookmark(id, LocalDateTime.now()));
+
+        return new PostBookmarkResponse(true);
+    }
+
+    @Transactional
+    public PostBookmarkResponse delete(Long userId, Long postId) {
+        validateBookmarkablePost(postId);
+
+        PostBookmarkId id = new PostBookmarkId(userId, postId);
+        if (postBookmarkRepository.existsById(id)) {
+            postBookmarkRepository.deleteById(id);
+        }
+
+        return new PostBookmarkResponse(false);
+    }
+
+    private void validateBookmarkablePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.POST_ALREADY_DELETED);
+        }
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkService.java
@@ -9,6 +9,7 @@ import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,21 +24,26 @@ public class PostBookmarkService {
 
     @Transactional
     public PostBookmarkResponse create(Long userId, Long postId) {
-        validateBookmarkablePost(postId);
+        Post post = getPostOrThrow(postId);
+        validateNotDeleted(post);
 
         PostBookmarkId id = new PostBookmarkId(userId, postId);
         if (postBookmarkRepository.existsById(id)) {
             throw new CustomException(PostErrorCode.DUPLICATE_REQUEST);
         }
 
-        postBookmarkRepository.save(new PostBookmark(id, LocalDateTime.now()));
+        try {
+            postBookmarkRepository.saveAndFlush(new PostBookmark(id, LocalDateTime.now()));
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(PostErrorCode.DUPLICATE_REQUEST);
+        }
 
         return new PostBookmarkResponse(true);
     }
 
     @Transactional
     public PostBookmarkResponse delete(Long userId, Long postId) {
-        validateBookmarkablePost(postId);
+        getPostOrThrow(postId);
 
         PostBookmarkId id = new PostBookmarkId(userId, postId);
         if (postBookmarkRepository.existsById(id)) {
@@ -47,9 +53,12 @@ public class PostBookmarkService {
         return new PostBookmarkResponse(false);
     }
 
-    private void validateBookmarkablePost(Long postId) {
-        Post post = postRepository.findById(postId)
+    private Post getPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+    }
+
+    private void validateNotDeleted(Post post) {
         if (post.isDeleted()) {
             throw new CustomException(PostErrorCode.POST_ALREADY_DELETED);
         }

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -996,6 +996,53 @@ class PostControllerTest {
         assertThat(bookmarkCount).isZero();
     }
 
+    // 정상 케이스: 삭제된 게시물이어도 기존 북마크는 취소할 수 있다.
+    @Test
+    void deleteBookmarkAllowsDeletedPostAndReturnsFalse() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "삭제된 북마크 글", "본문입니다", true, now);
+        insertPostBookmark(TEST_USER_ID, postId, now);
+
+        mockMvc.perform(delete("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+
+        Integer bookmarkCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM post_bookmarks WHERE user_id = ? AND post_id = ?",
+                Integer.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(bookmarkCount).isZero();
+    }
+
+    // 정상 케이스: 북마크가 없는 게시물에 취소 요청이 와도 멱등하게 isBookmarked=false를 반환한다.
+    @Test
+    void deleteBookmarkWithoutExistingBookmarkReturnsFalse() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "북마크 없는 글", "본문입니다", false, now);
+
+        mockMvc.perform(delete("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+
+        Integer bookmarkCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM post_bookmarks WHERE user_id = ? AND post_id = ?",
+                Integer.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(bookmarkCount).isZero();
+    }
+
     // 실패 케이스: 존재하지 않는 게시물을 북마크하면 404 Not Found와 POST_NOT_FOUND를 반환한다.
     @Test
     void createBookmarkRejectsNotFoundPost() throws Exception {

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -68,6 +68,7 @@ class PostControllerTest {
 
     @BeforeEach
     void setUp() {
+        jdbcTemplate.update("DELETE FROM post_bookmarks");
         jdbcTemplate.update("DELETE FROM post_votes");
         jdbcTemplate.update("DELETE FROM image_assets");
         jdbcTemplate.update("DELETE FROM posts");
@@ -932,6 +933,95 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.code").value("WRONG_POSTID_TYPE"));
     }
 
+    // 정상 케이스: 인증된 사용자가 게시물을 북마크하면 post_bookmarks에 저장하고 isBookmarked=true를 반환한다.
+    @Test
+    void createBookmarkPersistsBookmarkAndReturnsTrue() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "북마크할 글", "본문입니다", false, now);
+
+        mockMvc.perform(post("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(true));
+
+        Integer bookmarkCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM post_bookmarks WHERE user_id = ? AND post_id = ?",
+                Integer.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(bookmarkCount).isEqualTo(1);
+    }
+
+    // 실패 케이스: 이미 북마크한 게시물을 다시 북마크하면 409 Conflict와 DUPLICATE_REQUEST를 반환한다.
+    @Test
+    void createBookmarkRejectsDuplicateBookmark() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "이미 북마크한 글", "본문입니다", false, now);
+        insertPostBookmark(TEST_USER_ID, postId, now);
+
+        mockMvc.perform(post("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_REQUEST"));
+    }
+
+    // 정상 케이스: 인증된 사용자가 북마크를 취소하면 post_bookmarks에서 삭제하고 isBookmarked=false를 반환한다.
+    @Test
+    void deleteBookmarkRemovesBookmarkAndReturnsFalse() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "북마크 취소할 글", "본문입니다", false, now);
+        insertPostBookmark(TEST_USER_ID, postId, now);
+
+        mockMvc.perform(delete("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+
+        Integer bookmarkCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM post_bookmarks WHERE user_id = ? AND post_id = ?",
+                Integer.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(bookmarkCount).isZero();
+    }
+
+    // 실패 케이스: 존재하지 않는 게시물을 북마크하면 404 Not Found와 POST_NOT_FOUND를 반환한다.
+    @Test
+    void createBookmarkRejectsNotFoundPost() throws Exception {
+        stubAuthenticatedUser();
+
+        mockMvc.perform(post("/api/posts/{postId}/bookmarks", 9999L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_NOT_FOUND"));
+    }
+
+    // 실패 케이스: 삭제된 게시물을 북마크하면 404 Not Found와 POST_ALREADY_DELETED를 반환한다.
+    @Test
+    void createBookmarkRejectsDeletedPost() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "삭제된 글", "본문입니다", true, now);
+
+        mockMvc.perform(post("/api/posts/{postId}/bookmarks", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_ALREADY_DELETED"));
+    }
+
     private void insertUser(Long userId, String nickname, LocalDateTime now) {
         jdbcTemplate.update(
                 """
@@ -1018,6 +1108,20 @@ class PostControllerTest {
                 postId,
                 myVote,
                 now,
+                now
+        );
+    }
+
+    private void insertPostBookmark(Long userId, Long postId, LocalDateTime now) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO post_bookmarks
+                    (user_id, post_id, created_at)
+                VALUES
+                    (?, ?, ?)
+                """,
+                userId,
+                postId,
                 now
         );
     }

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostBookmarkServiceTest.java
@@ -1,0 +1,46 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.post.domain.Post;
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmark;
+import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;
+import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PostBookmarkServiceTest {
+
+    private final PostRepository postRepository = mock(PostRepository.class);
+    private final PostBookmarkRepository postBookmarkRepository = mock(PostBookmarkRepository.class);
+    private final PostBookmarkService postBookmarkService = new PostBookmarkService(
+            postRepository,
+            postBookmarkRepository
+    );
+
+    @Test
+    void createBookmarkConvertsDuplicateKeyViolationToDuplicateRequest() {
+        Long userId = 1L;
+        Long postId = 1234L;
+        Post post = Post.builder()
+                .id(postId)
+                .build();
+
+        when(postRepository.findById(postId))
+                .thenReturn(Optional.of(post));
+        when(postBookmarkRepository.saveAndFlush(any(PostBookmark.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate bookmark"));
+
+        assertThatThrownBy(() -> postBookmarkService.create(userId, postId))
+                .isInstanceOfSatisfying(CustomException.class, exception ->
+                        assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.DUPLICATE_REQUEST));
+    }
+}


### PR DESCRIPTION
## 📋 변경 사항

게시물 북마크 등록/취소 API를 구현했습니다.

- `POST /api/posts/{postId}/bookmarks` 추가
  - 북마크 성공 시 `{ "isBookmarked": true }` 반환
  - 이미 북마크된 경우 `409 DUPLICATE_REQUEST` 반환
- `DELETE /api/posts/{postId}/bookmarks` 추가
  - 북마크 취소 성공 시 `{ "isBookmarked": false }` 반환
- `post_bookmarks` 테이블 매핑을 위한 엔티티, 복합 ID, 레포지토리 추가
- 게시물 존재 여부 및 삭제 여부 검증 추가
  - 존재하지 않는 게시물: `POST_NOT_FOUND`
  - 삭제된 게시물: `POST_ALREADY_DELETED`
- 북마크 API 컨트롤러 테스트 추가

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

```bash
./gradlew test --tests com.hogu.am_i_hogu.domain.post.controller.PostControllerTest
BUILD SUCCESSFUL

./gradlew test
BUILD SUCCESSFUL
```

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 링크해주세요 -->

- Closes #21 