### PR TITLE
feat: 투표/투표취소 api 구현

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
@@ -2,15 +2,18 @@ package com.hogu.am_i_hogu.domain.post.controller;
 
 import com.hogu.am_i_hogu.domain.post.dto.request.PostCreateRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostUpdateRequest;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostBookmarkResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostCreateResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostUpdateResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
 import com.hogu.am_i_hogu.domain.post.service.PostBookmarkService;
 import com.hogu.am_i_hogu.domain.post.service.PostCreateService;
 import com.hogu.am_i_hogu.domain.post.service.PostDeleteService;
 import com.hogu.am_i_hogu.domain.post.service.PostDetailService;
 import com.hogu.am_i_hogu.domain.post.service.PostUpdateService;
+import com.hogu.am_i_hogu.domain.post.service.PostVoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +29,7 @@ public class PostController {
     private final PostUpdateService postUpdateService;
     private final PostDeleteService postDeleteService;
     private final PostBookmarkService postBookmarkService;
+    private final PostVoteService postVoteService;
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId, Authentication authentication) {
@@ -86,6 +90,29 @@ public class PostController {
     ) {
         Long userId = Long.valueOf(authentication.getName());
         PostBookmarkResponse response = postBookmarkService.delete(userId, postId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{postId}/votes")
+    public ResponseEntity<PostVoteResponse> vote(
+            @PathVariable Long postId,
+            Authentication authentication,
+            @RequestBody(required = false) PostVoteRequest request
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+        PostVoteResponse response = postVoteService.vote(userId, postId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{postId}/votes")
+    public ResponseEntity<PostVoteResponse> cancelVote(
+            @PathVariable Long postId,
+            Authentication authentication
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+        PostVoteResponse response = postVoteService.cancel(userId, postId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostVote.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/domain/PostVote.java
@@ -27,4 +27,16 @@ public class PostVote {
 
     @Column(nullable = false)
     private LocalDateTime updatedAt;
+
+    public PostVote(PostVoteId id, String myVote, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.myVote = myVote;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public void updateVote(String myVote, LocalDateTime updatedAt) {
+        this.myVote = myVote;
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/PostVoteCounts.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/PostVoteCounts.java
@@ -2,11 +2,17 @@ package com.hogu.am_i_hogu.domain.post.dto;
 
 public record PostVoteCounts(
         Long hoguVoteCount,
-        Long notHoguVoteCount
+        Long notHoguVoteCount,
+        Long votedPostCount
 ) {
+    public PostVoteCounts(Long hoguVoteCount, Long notHoguVoteCount) {
+        this(hoguVoteCount, notHoguVoteCount, 0L);
+    }
+
     public PostVoteCounts {
         hoguVoteCount = hoguVoteCount == null ? 0L : hoguVoteCount;
         notHoguVoteCount = notHoguVoteCount == null ? 0L : notHoguVoteCount;
+        votedPostCount = votedPostCount == null ? 0L : votedPostCount;
     }
 
     public long totalVoteCount() {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/PostVoteCounts.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/PostVoteCounts.java
@@ -1,0 +1,15 @@
+package com.hogu.am_i_hogu.domain.post.dto;
+
+public record PostVoteCounts(
+        Long hoguVoteCount,
+        Long notHoguVoteCount
+) {
+    public PostVoteCounts {
+        hoguVoteCount = hoguVoteCount == null ? 0L : hoguVoteCount;
+        notHoguVoteCount = notHoguVoteCount == null ? 0L : notHoguVoteCount;
+    }
+
+    public long totalVoteCount() {
+        return hoguVoteCount + notHoguVoteCount;
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
@@ -1,0 +1,4 @@
+package com.hogu.am_i_hogu.domain.post.dto.request;
+
+public record PostVoteRequest(String myVote) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements ErrorCodeType {
     EMPTY_REQUEST_BODY(HttpStatus.BAD_REQUEST, "EMPTY_REQUEST_BODY"),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE"),
+    INVALID_MYVOTE(HttpStatus.BAD_REQUEST, "INVALID_MYVOTE"),
     WRONG_POSTID_TYPE(HttpStatus.BAD_REQUEST, "WRONG_POSTID_TYPE"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND"),
     POST_ALREADY_DELETED(HttpStatus.NOT_FOUND, "POST_ALREADY_DELETED"),

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
@@ -48,11 +48,14 @@ public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> 
     @Query("""
             SELECT new com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts(
                 SUM(CASE WHEN pv.myVote = 'HOGU' THEN 1 ELSE 0 END),
-                SUM(CASE WHEN pv.myVote = 'NOT_HOGU' THEN 1 ELSE 0 END)
+                SUM(CASE WHEN pv.myVote = 'NOT_HOGU' THEN 1 ELSE 0 END),
+                COUNT(DISTINCT p.id)
             )
             FROM PostVote pv
             JOIN Post p ON p.id = pv.id.postId
             WHERE p.writer.id = :writerUserId
+              AND p.isDeleted = false
+              AND pv.myVote IN ('HOGU', 'NOT_HOGU')
             """)
     PostVoteCounts countByWriterUserId(@Param("writerUserId") Long writerUserId);
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
@@ -25,6 +25,10 @@ public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> 
             VALUES
                 (:userId, :postId, :myVote, :now, :now)
             ON DUPLICATE KEY UPDATE
+                created_at = CASE
+                    WHEN my_vote = 'NONE' THEN VALUES(created_at)
+                    ELSE created_at
+                END,
                 my_vote = VALUES(my_vote),
                 updated_at = VALUES(updated_at)
             """, nativeQuery = true)

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
@@ -5,6 +5,7 @@ import com.hogu.am_i_hogu.domain.post.domain.PostVoteId;
 import com.hogu.am_i_hogu.domain.user.dto.MyVoteSummary;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -15,6 +16,23 @@ import java.util.Optional;
 
 @Repository
 public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> {
+
+    @Modifying
+    @Query(value = """
+            INSERT INTO post_votes
+                (user_id, post_id, my_vote, created_at, updated_at)
+            VALUES
+                (:userId, :postId, :myVote, :now, :now)
+            ON DUPLICATE KEY UPDATE
+                my_vote = VALUES(my_vote),
+                updated_at = VALUES(updated_at)
+            """, nativeQuery = true)
+    int upsertVote(
+            @Param("userId") Long userId,
+            @Param("postId") Long postId,
+            @Param("myVote") String myVote,
+            @Param("now") LocalDateTime now
+    );
 
     @Query("""
             SELECT COUNT(pv)

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
@@ -2,6 +2,7 @@ package com.hogu.am_i_hogu.domain.post.repository;
 
 import com.hogu.am_i_hogu.domain.post.domain.PostVote;
 import com.hogu.am_i_hogu.domain.post.domain.PostVoteId;
+import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
 import com.hogu.am_i_hogu.domain.user.dto.MyVoteSummary;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -35,33 +36,25 @@ public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> 
     );
 
     @Query("""
-            SELECT COUNT(pv)
+            SELECT new com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts(
+                SUM(CASE WHEN pv.myVote = 'HOGU' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN pv.myVote = 'NOT_HOGU' THEN 1 ELSE 0 END)
+            )
             FROM PostVote pv
             WHERE pv.id.postId = :postId
-              AND pv.myVote = :myVote
             """)
-    long countByPostIdAndMyVote(@Param("postId") Long postId, @Param("myVote") String myVote);
+    PostVoteCounts countByPostId(@Param("postId") Long postId);
 
     @Query("""
-            SELECT COUNT(pv)
+            SELECT new com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts(
+                SUM(CASE WHEN pv.myVote = 'HOGU' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN pv.myVote = 'NOT_HOGU' THEN 1 ELSE 0 END)
+            )
             FROM PostVote pv
             JOIN Post p ON p.id = pv.id.postId
             WHERE p.writer.id = :writerUserId
-              AND pv.myVote = :myVote
             """)
-    long countByWriterUserIdAndMyVote(
-            @Param("writerUserId") Long writerUserId,
-            @Param("myVote") String myVote
-    );
-
-    @Query("""
-            SELECT COUNT(pv)
-            FROM PostVote pv
-            JOIN Post p ON p.id = pv.id.postId
-            WHERE p.writer.id = :writerUserId
-              AND pv.myVote IN ('HOGU', 'NOT_HOGU')
-            """)
-    long countEffectiveVotesByWriterUserId(@Param("writerUserId") Long writerUserId);
+    PostVoteCounts countByWriterUserId(@Param("writerUserId") Long writerUserId);
 
     @Query("""
             SELECT pv

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostVoteRepository.java
@@ -25,6 +25,27 @@ public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> 
     long countByPostIdAndMyVote(@Param("postId") Long postId, @Param("myVote") String myVote);
 
     @Query("""
+            SELECT COUNT(pv)
+            FROM PostVote pv
+            JOIN Post p ON p.id = pv.id.postId
+            WHERE p.writer.id = :writerUserId
+              AND pv.myVote = :myVote
+            """)
+    long countByWriterUserIdAndMyVote(
+            @Param("writerUserId") Long writerUserId,
+            @Param("myVote") String myVote
+    );
+
+    @Query("""
+            SELECT COUNT(pv)
+            FROM PostVote pv
+            JOIN Post p ON p.id = pv.id.postId
+            WHERE p.writer.id = :writerUserId
+              AND pv.myVote IN ('HOGU', 'NOT_HOGU')
+            """)
+    long countEffectiveVotesByWriterUserId(@Param("writerUserId") Long writerUserId);
+
+    @Query("""
             SELECT pv
             FROM PostVote pv
             WHERE pv.id.postId = :postId
@@ -45,6 +66,7 @@ public interface PostVoteRepository extends JpaRepository<PostVote, PostVoteId> 
             FROM PostVote pv
             JOIN Post p ON p.id = pv.id.postId
             WHERE pv.id.userId = :userId
+                AND pv.myVote <> 'NONE'
                 AND (
                     :cursorCreatedAt IS NULL
                     OR pv.createdAt < :cursorCreatedAt

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDeleteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDeleteService.java
@@ -5,6 +5,7 @@ import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import com.hogu.am_i_hogu.domain.user.service.WriterHoguStatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class PostDeleteService {
     private final PostRepository postRepository;
+    private final WriterHoguStatService writerHoguStatService;
 
     /**
      * 게시물을 soft delete 처리한다.
@@ -27,7 +29,9 @@ public class PostDeleteService {
         Post post = getPostOrThrow(postId);
         validateDeletable(post, userId);
 
-        post.delete(LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        post.delete(now);
+        writerHoguStatService.recalculate(post.getWriter().getId(), now);
     }
 
     /**

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDetailService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDetailService.java
@@ -4,6 +4,7 @@ import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
 import com.hogu.am_i_hogu.domain.post.domain.PostVote;
+import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostWriterResponse;
@@ -103,8 +104,9 @@ public class PostDetailService {
      * @return 투표 집계 응답
      */
     private PostVoteResponse getVoteResponse(Long postId, Long viewerUserId) {
-        int yesVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, HOGU_VOTE));
-        int noVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, NOT_HOGU_VOTE));
+        PostVoteCounts voteCounts = postVoteRepository.countByPostId(postId);
+        int yesVotes = Math.toIntExact(voteCounts.hoguVoteCount());
+        int noVotes = Math.toIntExact(voteCounts.notHoguVoteCount());
         String myVote = viewerUserId == null
                 ? NONE_VOTE
                 : postVoteRepository.findByPostIdAndUserId(postId, viewerUserId)

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -1,0 +1,113 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.post.domain.Post;
+import com.hogu.am_i_hogu.domain.post.domain.PostVote;
+import com.hogu.am_i_hogu.domain.post.domain.PostVoteId;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
+import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
+import com.hogu.am_i_hogu.domain.user.domain.UserHoguStat;
+import com.hogu.am_i_hogu.domain.user.repository.UserHoguStatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class PostVoteService {
+    private static final String HOGU_VOTE = "HOGU";
+    private static final String NOT_HOGU_VOTE = "NOT_HOGU";
+    private static final String NONE_VOTE = "NONE";
+
+    private final PostRepository postRepository;
+    private final PostVoteRepository postVoteRepository;
+    private final UserHoguStatRepository userHoguStatRepository;
+
+    @Transactional
+    public PostVoteResponse vote(Long userId, Long postId, PostVoteRequest request) {
+        validateVoteRequest(request);
+
+        Post post = getPostOrThrow(postId);
+        validateNotDeleted(post);
+        validateNotWriter(post, userId);
+
+        LocalDateTime now = LocalDateTime.now();
+        PostVoteId id = new PostVoteId(userId, postId);
+        PostVote postVote = postVoteRepository.findById(id)
+                .orElseGet(() -> new PostVote(id, request.myVote(), now, now));
+        postVote.updateVote(request.myVote(), now);
+        postVoteRepository.save(postVote);
+
+        updateWriterHoguStat(post.getWriter().getId(), now);
+
+        return getVoteResponse(postId, request.myVote());
+    }
+
+    @Transactional
+    public PostVoteResponse cancel(Long userId, Long postId) {
+        Post post = getPostOrThrow(postId);
+        validateNotDeleted(post);
+        validateNotWriter(post, userId);
+
+        LocalDateTime now = LocalDateTime.now();
+        postVoteRepository.findById(new PostVoteId(userId, postId))
+                .ifPresent(postVote -> postVote.updateVote(NONE_VOTE, now));
+
+        updateWriterHoguStat(post.getWriter().getId(), now);
+
+        return getVoteResponse(postId, NONE_VOTE);
+    }
+
+    private void validateVoteRequest(PostVoteRequest request) {
+        if (request == null) {
+            throw new CustomException(PostErrorCode.EMPTY_REQUEST_BODY);
+        }
+        if (!HOGU_VOTE.equals(request.myVote()) && !NOT_HOGU_VOTE.equals(request.myVote())) {
+            throw new CustomException(PostErrorCode.INVALID_MYVOTE);
+        }
+    }
+
+    private Post getPostOrThrow(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+    }
+
+    private void validateNotDeleted(Post post) {
+        if (post.isDeleted()) {
+            throw new CustomException(PostErrorCode.POST_ALREADY_DELETED);
+        }
+    }
+
+    private void validateNotWriter(Post post, Long userId) {
+        if (post.getWriter().getId().equals(userId)) {
+            throw new CustomException(CommonErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+
+    private void updateWriterHoguStat(Long writerUserId, LocalDateTime now) {
+        int hoguVoteCount = Math.toIntExact(
+                postVoteRepository.countByWriterUserIdAndMyVote(writerUserId, HOGU_VOTE)
+        );
+        int totalVoteCount = Math.toIntExact(
+                postVoteRepository.countEffectiveVotesByWriterUserId(writerUserId)
+        );
+
+        UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
+                .orElseGet(() -> new UserHoguStat(writerUserId, now));
+        stat.updateVoteStats(hoguVoteCount, totalVoteCount, now);
+        userHoguStatRepository.save(stat);
+    }
+
+    private PostVoteResponse getVoteResponse(Long postId, String myVote) {
+        int yesVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, HOGU_VOTE));
+        int noVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, NOT_HOGU_VOTE));
+
+        return new PostVoteResponse(yesVotes + noVotes, yesVotes, noVotes, myVote);
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -4,6 +4,7 @@ import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
 import com.hogu.am_i_hogu.domain.post.domain.PostVoteId;
+import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
@@ -86,12 +87,9 @@ public class PostVoteService {
     }
 
     private void updateWriterHoguStat(Long writerUserId, LocalDateTime now) {
-        int hoguVoteCount = Math.toIntExact(
-                postVoteRepository.countByWriterUserIdAndMyVote(writerUserId, HOGU_VOTE)
-        );
-        int totalVoteCount = Math.toIntExact(
-                postVoteRepository.countEffectiveVotesByWriterUserId(writerUserId)
-        );
+        PostVoteCounts voteCounts = postVoteRepository.countByWriterUserId(writerUserId);
+        int hoguVoteCount = Math.toIntExact(voteCounts.hoguVoteCount());
+        int totalVoteCount = Math.toIntExact(voteCounts.totalVoteCount());
 
         UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
                 .orElseGet(() -> new UserHoguStat(writerUserId, now));
@@ -100,8 +98,9 @@ public class PostVoteService {
     }
 
     private PostVoteResponse getVoteResponse(Long postId, String myVote) {
-        int yesVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, HOGU_VOTE));
-        int noVotes = Math.toIntExact(postVoteRepository.countByPostIdAndMyVote(postId, NOT_HOGU_VOTE));
+        PostVoteCounts voteCounts = postVoteRepository.countByPostId(postId);
+        int yesVotes = Math.toIntExact(voteCounts.hoguVoteCount());
+        int noVotes = Math.toIntExact(voteCounts.notHoguVoteCount());
 
         return new PostVoteResponse(yesVotes + noVotes, yesVotes, noVotes, myVote);
     }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -3,7 +3,6 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
-import com.hogu.am_i_hogu.domain.post.domain.PostVote;
 import com.hogu.am_i_hogu.domain.post.domain.PostVoteId;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
@@ -38,11 +37,7 @@ public class PostVoteService {
         validateNotWriter(post, userId);
 
         LocalDateTime now = LocalDateTime.now();
-        PostVoteId id = new PostVoteId(userId, postId);
-        PostVote postVote = postVoteRepository.findById(id)
-                .orElseGet(() -> new PostVote(id, request.myVote(), now, now));
-        postVote.updateVote(request.myVote(), now);
-        postVoteRepository.save(postVote);
+        postVoteRepository.upsertVote(userId, postId, request.myVote(), now);
 
         updateWriterHoguStat(post.getWriter().getId(), now);
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -10,8 +10,7 @@ import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
-import com.hogu.am_i_hogu.domain.user.domain.UserHoguStat;
-import com.hogu.am_i_hogu.domain.user.repository.UserHoguStatRepository;
+import com.hogu.am_i_hogu.domain.user.service.WriterHoguStatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,7 +26,7 @@ public class PostVoteService {
 
     private final PostRepository postRepository;
     private final PostVoteRepository postVoteRepository;
-    private final UserHoguStatRepository userHoguStatRepository;
+    private final WriterHoguStatService writerHoguStatService;
 
     @Transactional
     public PostVoteResponse vote(Long userId, Long postId, PostVoteRequest request) {
@@ -40,7 +39,7 @@ public class PostVoteService {
         LocalDateTime now = LocalDateTime.now();
         postVoteRepository.upsertVote(userId, postId, request.myVote(), now);
 
-        updateWriterHoguStat(post.getWriter().getId(), now);
+        writerHoguStatService.recalculate(post.getWriter().getId(), now);
 
         return getVoteResponse(postId, request.myVote());
     }
@@ -55,7 +54,7 @@ public class PostVoteService {
         postVoteRepository.findById(new PostVoteId(userId, postId))
                 .ifPresent(postVote -> postVote.updateVote(NONE_VOTE, now));
 
-        updateWriterHoguStat(post.getWriter().getId(), now);
+        writerHoguStatService.recalculate(post.getWriter().getId(), now);
 
         return getVoteResponse(postId, NONE_VOTE);
     }
@@ -84,18 +83,6 @@ public class PostVoteService {
         if (post.getWriter().getId().equals(userId)) {
             throw new CustomException(CommonErrorCode.FORBIDDEN_ACCESS);
         }
-    }
-
-    private void updateWriterHoguStat(Long writerUserId, LocalDateTime now) {
-        PostVoteCounts voteCounts = postVoteRepository.countByWriterUserId(writerUserId);
-        int votedPostCount = Math.toIntExact(voteCounts.votedPostCount());
-        int hoguVoteCount = Math.toIntExact(voteCounts.hoguVoteCount());
-        int totalVoteCount = Math.toIntExact(voteCounts.totalVoteCount());
-
-        UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
-                .orElseGet(() -> new UserHoguStat(writerUserId, now));
-        stat.updateVoteStats(votedPostCount, hoguVoteCount, totalVoteCount, now);
-        userHoguStatRepository.save(stat);
     }
 
     private PostVoteResponse getVoteResponse(Long postId, String myVote) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -88,12 +88,13 @@ public class PostVoteService {
 
     private void updateWriterHoguStat(Long writerUserId, LocalDateTime now) {
         PostVoteCounts voteCounts = postVoteRepository.countByWriterUserId(writerUserId);
+        int votedPostCount = Math.toIntExact(voteCounts.votedPostCount());
         int hoguVoteCount = Math.toIntExact(voteCounts.hoguVoteCount());
         int totalVoteCount = Math.toIntExact(voteCounts.totalVoteCount());
 
         UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
                 .orElseGet(() -> new UserHoguStat(writerUserId, now));
-        stat.updateVoteStats(hoguVoteCount, totalVoteCount, now);
+        stat.updateVoteStats(votedPostCount, hoguVoteCount, totalVoteCount, now);
         userHoguStatRepository.save(stat);
     }
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
@@ -40,4 +40,17 @@ public class UserHoguStat {
         this.userId = userId;
         this.updatedAt = updatedAt;
     }
+
+    public void updateVoteStats(
+            int hoguVoteCount,
+            int totalVoteCount,
+            LocalDateTime updatedAt
+    ) {
+        this.hoguVoteCount = hoguVoteCount;
+        this.totalVoteCount = totalVoteCount;
+        this.hoguIndex = totalVoteCount == 0
+                ? 0
+                : (int) Math.round(hoguVoteCount * 100.0 / totalVoteCount);
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
@@ -19,6 +19,9 @@ public class UserHoguStat {
     private Long userId;
 
     @Column(nullable = false)
+    private Integer votedPostCount = 0;
+
+    @Column(nullable = false)
     private Integer hoguVoteCount = 0;
 
     @Column(nullable = false)
@@ -42,10 +45,12 @@ public class UserHoguStat {
     }
 
     public void updateVoteStats(
+            int votedPostCount,
             int hoguVoteCount,
             int totalVoteCount,
             LocalDateTime updatedAt
     ) {
+        this.votedPostCount = votedPostCount;
         this.hoguVoteCount = hoguVoteCount;
         this.totalVoteCount = totalVoteCount;
         this.hoguIndex = totalVoteCount == 0

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/domain/UserHoguStat.java
@@ -33,9 +33,6 @@ public class UserHoguStat {
     @Column(nullable = false)
     private LocalDateTime updatedAt;
 
-    @Column(nullable = false)
-    private Integer votedPostCount = 0;
-
     public UserHoguStat(
             Long userId,
             LocalDateTime updatedAt

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatService.java
@@ -1,0 +1,31 @@
+package com.hogu.am_i_hogu.domain.user.service;
+
+import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
+import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
+import com.hogu.am_i_hogu.domain.user.domain.UserHoguStat;
+import com.hogu.am_i_hogu.domain.user.repository.UserHoguStatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class WriterHoguStatService {
+    private final PostVoteRepository postVoteRepository;
+    private final UserHoguStatRepository userHoguStatRepository;
+
+    @Transactional
+    public void recalculate(Long writerUserId, LocalDateTime now) {
+        PostVoteCounts voteCounts = postVoteRepository.countByWriterUserId(writerUserId);
+        int votedPostCount = Math.toIntExact(voteCounts.votedPostCount());
+        int hoguVoteCount = Math.toIntExact(voteCounts.hoguVoteCount());
+        int totalVoteCount = Math.toIntExact(voteCounts.totalVoteCount());
+
+        UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
+                .orElseGet(() -> new UserHoguStat(writerUserId, now));
+        stat.updateVoteStats(votedPostCount, hoguVoteCount, totalVoteCount, now);
+        userHoguStatRepository.save(stat);
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatService.java
@@ -1,5 +1,7 @@
 package com.hogu.am_i_hogu.domain.user.service;
 
+import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
+import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
 import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
 import com.hogu.am_i_hogu.domain.user.domain.UserHoguStat;
@@ -24,7 +26,7 @@ public class WriterHoguStatService {
         int totalVoteCount = Math.toIntExact(voteCounts.totalVoteCount());
 
         UserHoguStat stat = userHoguStatRepository.findById(writerUserId)
-                .orElseGet(() -> new UserHoguStat(writerUserId, now));
+                .orElseThrow(() -> new CustomException(CommonErrorCode.SERVER_ERROR));
         stat.updateVoteStats(votedPostCount, hoguVoteCount, totalVoteCount, now);
         userHoguStatRepository.save(stat);
     }

--- a/src/main/resources/db/migration/V8__add_voted_post_count.sql
+++ b/src/main/resources/db/migration/V8__add_voted_post_count.sql
@@ -1,3 +1,0 @@
--- alter voted_post_count column
-ALTER TABLE user_hogu_stats
-    ADD COLUMN voted_post_count INT NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V8__add_voted_post_count_to_user_hogu_stats.sql
+++ b/src/main/resources/db/migration/V8__add_voted_post_count_to_user_hogu_stats.sql
@@ -1,0 +1,3 @@
+-- add voted post count to user hogu stats
+ALTER TABLE user_hogu_stats
+    ADD COLUMN voted_post_count INT NOT NULL DEFAULT 0;

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -866,6 +866,7 @@ class PostControllerTest {
 
         Long postId = 1234L;
         LocalDateTime now = LocalDateTime.now();
+        insertUserHoguStat(TEST_USER_ID, now);
         insertPost(postId, TEST_USER_ID, "USED_TRADE", "삭제할 글", "본문입니다", false, now);
 
         mockMvc.perform(delete("/api/posts/{postId}", postId)
@@ -1158,11 +1159,12 @@ class PostControllerTest {
         Long otherVoterId = 3L;
         Long postId = 1234L;
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime existingVoteCreatedAt = now.minusDays(1);
         insertUser(writerUserId, "writer", now);
         insertUser(otherVoterId, "other-voter", now);
         insertUserHoguStat(writerUserId, now);
         insertPost(postId, writerUserId, "USED_TRADE", "투표 변경할 글", "본문입니다", false, now);
-        insertPostVote(TEST_USER_ID, postId, "NOT_HOGU", now);
+        insertPostVote(TEST_USER_ID, postId, "NOT_HOGU", existingVoteCreatedAt);
         insertPostVote(otherVoterId, postId, "HOGU", now);
 
         String requestBody = """
@@ -1193,8 +1195,15 @@ class PostControllerTest {
                 TEST_USER_ID,
                 postId
         );
+        LocalDateTime savedCreatedAt = jdbcTemplate.queryForObject(
+                "SELECT created_at FROM post_votes WHERE user_id = ? AND post_id = ?",
+                LocalDateTime.class,
+                TEST_USER_ID,
+                postId
+        );
         assertThat(voteRowCount).isEqualTo(1);
         assertThat(savedVote).isEqualTo("HOGU");
+        assertThat(savedCreatedAt).isBefore(now.minusHours(1));
         assertWriterHoguStat(writerUserId, 1, 2, 2, 100);
     }
 
@@ -1254,6 +1263,44 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.myVote").value("NONE"));
 
         assertWriterHoguStat(writerUserId, 0, 0, 0, 0);
+    }
+
+    // 정상 케이스: 취소 상태(NONE)에서 다시 투표하면 created_at을 새 투표 시점으로 갱신한다.
+    @Test
+    void voteOnPostUpdatesCreatedAtWhenRevotingAfterCancel() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime canceledVoteCreatedAt = now.minusDays(1);
+        LocalDateTime revoteRequestStartedAt = LocalDateTime.now().minusMinutes(1);
+        insertUser(writerUserId, "writer", now);
+        insertUserHoguStat(writerUserId, now);
+        insertPost(postId, writerUserId, "USED_TRADE", "재투표할 글", "본문입니다", false, now);
+        insertPostVote(TEST_USER_ID, postId, "NONE", canceledVoteCreatedAt);
+
+        String requestBody = """
+                {
+                  "myVote": "HOGU"
+                }
+                """;
+
+        mockMvc.perform(put("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.myVote").value("HOGU"));
+
+        LocalDateTime savedCreatedAt = jdbcTemplate.queryForObject(
+                "SELECT created_at FROM post_votes WHERE user_id = ? AND post_id = ?",
+                LocalDateTime.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(savedCreatedAt).isAfter(canceledVoteCreatedAt);
+        assertThat(savedCreatedAt).isAfter(revoteRequestStartedAt);
     }
 
     // 실패 케이스: 게시물 작성자는 자기 게시물에 투표할 수 없다.

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -887,6 +887,38 @@ class PostControllerTest {
         assertThat(deletedAt).isNotNull();
     }
 
+    // 정상 케이스: 투표가 있는 게시물을 삭제하면 해당 투표는 작성자 호구 통계에서 제외한다.
+    @Test
+    void deletePostRecalculatesWriterStatsExcludingDeletedPostVotes() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        Long voterId = 2L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(voterId, "voter", now);
+        insertUserHoguStat(TEST_USER_ID, now);
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "투표 있는 삭제 글", "본문입니다", false, now);
+        insertPostVote(voterId, postId, "HOGU", now);
+        jdbcTemplate.update(
+                """
+                UPDATE user_hogu_stats
+                SET voted_post_count = ?, hogu_vote_count = ?, total_vote_count = ?, hogu_index = ?
+                WHERE user_id = ?
+                """,
+                1,
+                1,
+                1,
+                100,
+                TEST_USER_ID
+        );
+
+        mockMvc.perform(delete("/api/posts/{postId}", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isNoContent());
+
+        assertWriterHoguStat(TEST_USER_ID, 0, 0, 0, 0);
+    }
+
     // 실패 케이스: 존재하지 않는 게시물을 삭제하면 404 Not Found와 POST_NOT_FOUND를 반환한다.
     @Test
     void deletePostRejectsNotFoundPost() throws Exception {

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -29,6 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -1078,6 +1079,175 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.code").value("POST_ALREADY_DELETED"));
     }
 
+    // 정상 케이스: 인증된 사용자가 게시물에 HOGU 투표하면 post_votes와 작성자 호구 통계를 갱신한다.
+    @Test
+    void voteOnPostCreatesVoteUpdatesWriterStatsAndReturnsSummary() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(writerUserId, "writer", now);
+        insertUserHoguStat(writerUserId, now);
+        insertPost(postId, writerUserId, "USED_TRADE", "투표할 글", "본문입니다", false, now);
+
+        String requestBody = """
+                {
+                  "myVote": "HOGU"
+                }
+                """;
+
+        mockMvc.perform(put("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalVotes").value(1))
+                .andExpect(jsonPath("$.yesVotes").value(1))
+                .andExpect(jsonPath("$.noVotes").value(0))
+                .andExpect(jsonPath("$.myVote").value("HOGU"));
+
+        String savedVote = jdbcTemplate.queryForObject(
+                "SELECT my_vote FROM post_votes WHERE user_id = ? AND post_id = ?",
+                String.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(savedVote).isEqualTo("HOGU");
+        assertWriterHoguStat(writerUserId, 1, 1, 100);
+    }
+
+    // 정상 케이스: 이미 투표한 사용자가 다른 선택지로 다시 투표하면 기존 row를 갱신한다.
+    @Test
+    void voteOnPostUpdatesExistingVoteAndRecalculatesWriterStats() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long otherVoterId = 3L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(writerUserId, "writer", now);
+        insertUser(otherVoterId, "other-voter", now);
+        insertUserHoguStat(writerUserId, now);
+        insertPost(postId, writerUserId, "USED_TRADE", "투표 변경할 글", "본문입니다", false, now);
+        insertPostVote(TEST_USER_ID, postId, "NOT_HOGU", now);
+        insertPostVote(otherVoterId, postId, "HOGU", now);
+
+        String requestBody = """
+                {
+                  "myVote": "HOGU"
+                }
+                """;
+
+        mockMvc.perform(put("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalVotes").value(2))
+                .andExpect(jsonPath("$.yesVotes").value(2))
+                .andExpect(jsonPath("$.noVotes").value(0))
+                .andExpect(jsonPath("$.myVote").value("HOGU"));
+
+        Integer voteRowCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM post_votes WHERE user_id = ? AND post_id = ?",
+                Integer.class,
+                TEST_USER_ID,
+                postId
+        );
+        String savedVote = jdbcTemplate.queryForObject(
+                "SELECT my_vote FROM post_votes WHERE user_id = ? AND post_id = ?",
+                String.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(voteRowCount).isEqualTo(1);
+        assertThat(savedVote).isEqualTo("HOGU");
+        assertWriterHoguStat(writerUserId, 2, 2, 100);
+    }
+
+    // 정상 케이스: 투표 취소는 row 삭제가 아니라 my_vote=NONE으로 갱신하고 집계에서 제외한다.
+    @Test
+    void cancelVoteMarksNoneUpdatesWriterStatsAndReturnsSummary() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long otherVoterId = 3L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(writerUserId, "writer", now);
+        insertUser(otherVoterId, "other-voter", now);
+        insertUserHoguStat(writerUserId, now);
+        insertPost(postId, writerUserId, "USED_TRADE", "투표 취소할 글", "본문입니다", false, now);
+        insertPostVote(TEST_USER_ID, postId, "HOGU", now);
+        insertPostVote(otherVoterId, postId, "NOT_HOGU", now);
+
+        mockMvc.perform(delete("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalVotes").value(1))
+                .andExpect(jsonPath("$.yesVotes").value(0))
+                .andExpect(jsonPath("$.noVotes").value(1))
+                .andExpect(jsonPath("$.myVote").value("NONE"));
+
+        String savedVote = jdbcTemplate.queryForObject(
+                "SELECT my_vote FROM post_votes WHERE user_id = ? AND post_id = ?",
+                String.class,
+                TEST_USER_ID,
+                postId
+        );
+        assertThat(savedVote).isEqualTo("NONE");
+        assertWriterHoguStat(writerUserId, 0, 1, 0);
+    }
+
+    // 실패 케이스: 게시물 작성자는 자기 게시물에 투표할 수 없다.
+    @Test
+    void voteOnPostRejectsWriterVote() throws Exception {
+        stubAuthenticatedUser();
+
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(postId, TEST_USER_ID, "USED_TRADE", "내 글", "본문입니다", false, now);
+
+        String requestBody = """
+                {
+                  "myVote": "HOGU"
+                }
+                """;
+
+        mockMvc.perform(put("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("FORBIDDEN_ACCESS"));
+    }
+
+    // 실패 케이스: myVote가 HOGU/NOT_HOGU가 아니면 INVALID_MYVOTE를 반환한다.
+    @Test
+    void voteOnPostRejectsInvalidMyVote() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(writerUserId, "writer", now);
+        insertPost(postId, writerUserId, "USED_TRADE", "투표할 글", "본문입니다", false, now);
+
+        String requestBody = """
+                {
+                  "myVote": "NONE"
+                }
+                """;
+
+        mockMvc.perform(put("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_MYVOTE"));
+    }
+
     private void insertUser(Long userId, String nickname, LocalDateTime now) {
         jdbcTemplate.update(
                 """
@@ -1168,6 +1338,22 @@ class PostControllerTest {
         );
     }
 
+    private void insertUserHoguStat(Long userId, LocalDateTime now) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO user_hogu_stats
+                    (user_id, hogu_vote_count, total_vote_count, hogu_index, updated_at)
+                VALUES
+                    (?, ?, ?, ?, ?)
+                """,
+                userId,
+                0,
+                0,
+                0,
+                now
+        );
+    }
+
     private void insertPostBookmark(Long userId, Long postId, LocalDateTime now) {
         jdbcTemplate.update(
                 """
@@ -1188,6 +1374,28 @@ class PostControllerTest {
                 Integer.class,
                 postId
         );
+    }
+
+    private void assertWriterHoguStat(Long writerUserId, int hoguVoteCount, int totalVoteCount, int hoguIndex) {
+        Integer savedHoguVoteCount = jdbcTemplate.queryForObject(
+                "SELECT hogu_vote_count FROM user_hogu_stats WHERE user_id = ?",
+                Integer.class,
+                writerUserId
+        );
+        Integer savedTotalVoteCount = jdbcTemplate.queryForObject(
+                "SELECT total_vote_count FROM user_hogu_stats WHERE user_id = ?",
+                Integer.class,
+                writerUserId
+        );
+        Integer savedHoguIndex = jdbcTemplate.queryForObject(
+                "SELECT hogu_index FROM user_hogu_stats WHERE user_id = ?",
+                Integer.class,
+                writerUserId
+        );
+
+        assertThat(savedHoguVoteCount).isEqualTo(hoguVoteCount);
+        assertThat(savedTotalVoteCount).isEqualTo(totalVoteCount);
+        assertThat(savedHoguIndex).isEqualTo(hoguIndex);
     }
 
     /**

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -1200,6 +1200,30 @@ class PostControllerTest {
         assertWriterHoguStat(writerUserId, 1, 0, 1, 0);
     }
 
+    // 정상 케이스: 마지막 유효 투표를 취소하면 투표 참여 게시물 수도 0으로 재집계한다.
+    @Test
+    void cancelLastVoteUpdatesWriterVotedPostCountToZero() throws Exception {
+        stubAuthenticatedUser();
+
+        Long writerUserId = 2L;
+        Long postId = 1234L;
+        LocalDateTime now = LocalDateTime.now();
+        insertUser(writerUserId, "writer", now);
+        insertUserHoguStat(writerUserId, now);
+        insertPost(postId, writerUserId, "USED_TRADE", "마지막 투표 취소할 글", "본문입니다", false, now);
+        insertPostVote(TEST_USER_ID, postId, "HOGU", now);
+
+        mockMvc.perform(delete("/api/posts/{postId}/votes", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalVotes").value(0))
+                .andExpect(jsonPath("$.yesVotes").value(0))
+                .andExpect(jsonPath("$.noVotes").value(0))
+                .andExpect(jsonPath("$.myVote").value("NONE"));
+
+        assertWriterHoguStat(writerUserId, 0, 0, 0, 0);
+    }
+
     // 실패 케이스: 게시물 작성자는 자기 게시물에 투표할 수 없다.
     @Test
     void voteOnPostRejectsWriterVote() throws Exception {

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -1114,7 +1114,7 @@ class PostControllerTest {
                 postId
         );
         assertThat(savedVote).isEqualTo("HOGU");
-        assertWriterHoguStat(writerUserId, 1, 1, 100);
+        assertWriterHoguStat(writerUserId, 1, 1, 1, 100);
     }
 
     // 정상 케이스: 이미 투표한 사용자가 다른 선택지로 다시 투표하면 기존 row를 갱신한다.
@@ -1163,7 +1163,7 @@ class PostControllerTest {
         );
         assertThat(voteRowCount).isEqualTo(1);
         assertThat(savedVote).isEqualTo("HOGU");
-        assertWriterHoguStat(writerUserId, 2, 2, 100);
+        assertWriterHoguStat(writerUserId, 1, 2, 2, 100);
     }
 
     // 정상 케이스: 투표 취소는 row 삭제가 아니라 my_vote=NONE으로 갱신하고 집계에서 제외한다.
@@ -1197,7 +1197,7 @@ class PostControllerTest {
                 postId
         );
         assertThat(savedVote).isEqualTo("NONE");
-        assertWriterHoguStat(writerUserId, 0, 1, 0);
+        assertWriterHoguStat(writerUserId, 1, 0, 1, 0);
     }
 
     // 실패 케이스: 게시물 작성자는 자기 게시물에 투표할 수 없다.
@@ -1376,7 +1376,18 @@ class PostControllerTest {
         );
     }
 
-    private void assertWriterHoguStat(Long writerUserId, int hoguVoteCount, int totalVoteCount, int hoguIndex) {
+    private void assertWriterHoguStat(
+            Long writerUserId,
+            int votedPostCount,
+            int hoguVoteCount,
+            int totalVoteCount,
+            int hoguIndex
+    ) {
+        Integer savedVotedPostCount = jdbcTemplate.queryForObject(
+                "SELECT voted_post_count FROM user_hogu_stats WHERE user_id = ?",
+                Integer.class,
+                writerUserId
+        );
         Integer savedHoguVoteCount = jdbcTemplate.queryForObject(
                 "SELECT hogu_vote_count FROM user_hogu_stats WHERE user_id = ?",
                 Integer.class,
@@ -1393,6 +1404,7 @@ class PostControllerTest {
                 writerUserId
         );
 
+        assertThat(savedVotedPostCount).isEqualTo(votedPostCount);
         assertThat(savedHoguVoteCount).isEqualTo(hoguVoteCount);
         assertThat(savedTotalVoteCount).isEqualTo(totalVoteCount);
         assertThat(savedHoguIndex).isEqualTo(hoguIndex);

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/controller/UserControllerTest.java
@@ -1284,6 +1284,34 @@ public class UserControllerTest {
 
     /**
      * 참여한 투표 리스트 조회 성공 테스트:
+     * 취소된 투표(myVote=NONE)는 참여한 투표 목록에서 제외되는지 확인
+     */
+    @Test
+    void getMyVotesExcludesCanceledVotes() throws Exception {
+        stubAuthenticatedUser();
+
+        insertUser(1L, "nickname", null);
+        insertUser(2L, "writer", null);
+
+        LocalDateTime olderCreatedAt = LocalDateTime.of(2026, 5, 1, 9, 0, 0);
+        LocalDateTime newerCreatedAt = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        insertPost(100L, 2L, "USED_TRADE", "유효한 투표 글", "content", false, olderCreatedAt);
+        insertPost(101L, 2L, "USED_TRADE", "취소된 투표 글", "content", false, newerCreatedAt);
+        insertPostVote(1L, 100L, "HOGU", olderCreatedAt);
+        insertPostVote(1L, 101L, "NONE", newerCreatedAt);
+
+        mockMvc.perform(get("/api/users/me/votes")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.votes.length()").value(1))
+                .andExpect(jsonPath("$.votes[0].myVote").value("HOGU"))
+                .andExpect(jsonPath("$.votes[0].post.postId").value(100L))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.nextCursor").value(Matchers.nullValue()));
+    }
+
+    /**
+     * 참여한 투표 리스트 조회 성공 테스트:
      * 인증된 사용자가 삭제된 게시물에 투표한 상태에서 요청을 보내고,
      * - (1) 응답 status가 200 OK인지 확인
      * - (2) 삭제된 게시물의 투표도 포함되는지 확인

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/service/WriterHoguStatServiceTest.java
@@ -1,0 +1,67 @@
+package com.hogu.am_i_hogu.domain.user.service;
+
+import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
+import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
+import com.hogu.am_i_hogu.domain.user.domain.UserHoguStat;
+import com.hogu.am_i_hogu.domain.user.repository.UserHoguStatRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WriterHoguStatServiceTest {
+    private final PostVoteRepository postVoteRepository = mock(PostVoteRepository.class);
+    private final UserHoguStatRepository userHoguStatRepository = mock(UserHoguStatRepository.class);
+    private final WriterHoguStatService writerHoguStatService = new WriterHoguStatService(
+            postVoteRepository,
+            userHoguStatRepository
+    );
+
+    // 정상 케이스: 작성자 통계 row가 이미 있으면 투표 재집계 결과로 값을 갱신하고 저장한다.
+    @Test
+    void recalculateUpdatesExistingWriterStat() {
+        Long writerUserId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        UserHoguStat stat = new UserHoguStat(writerUserId, now);
+        when(postVoteRepository.countByWriterUserId(writerUserId))
+                .thenReturn(new PostVoteCounts(2L, 3L, 4L));
+        when(userHoguStatRepository.findById(writerUserId))
+                .thenReturn(Optional.of(stat));
+
+        writerHoguStatService.recalculate(writerUserId, now);
+
+        assertThat(stat.getVotedPostCount()).isEqualTo(4);
+        assertThat(stat.getHoguVoteCount()).isEqualTo(2);
+        assertThat(stat.getTotalVoteCount()).isEqualTo(5);
+        assertThat(stat.getHoguIndex()).isEqualTo(40);
+        verify(userHoguStatRepository).save(stat);
+    }
+
+    // 실패 케이스: 정상 온보딩 유저라면 있어야 할 작성자 통계 row가 없으면 SERVER_ERROR를 반환한다.
+    @Test
+    void recalculateThrowsServerErrorWhenWriterStatDoesNotExist() {
+        Long writerUserId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        when(postVoteRepository.countByWriterUserId(writerUserId))
+                .thenReturn(new PostVoteCounts(0L, 0L, 0L));
+        when(userHoguStatRepository.findById(writerUserId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> writerHoguStatService.recalculate(writerUserId, now))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(CommonErrorCode.SERVER_ERROR);
+
+        verify(userHoguStatRepository, never()).save(any(UserHoguStat.class));
+    }
+}


### PR DESCRIPTION
## 📋 변경 사항

게시물 투표 및 투표 취소 API를 구현했습니다.

- `PUT /api/posts/{postId}/votes` 추가
  - `HOGU`, `NOT_HOGU` 투표 등록/변경
  - 잘못된 `myVote` 값은 `INVALID_MYVOTE` 반환
- `DELETE /api/posts/{postId}/votes` 추가
  - 투표 취소 시 `post_votes.my_vote = NONE`으로 갱신
- 게시물 작성자의 자기 글 투표 방지
  - `FORBIDDEN_ACCESS` 반환
- 투표 생성/변경/취소 시 작성자 `user_hogu_stats` 재계산
  - `hogu_vote_count`
  - `total_vote_count`
  - `hogu_index`
- `/api/users/me/votes` 조회에서 취소된 투표(`NONE`) 제외
- 투표 관련 컨트롤러 테스트 추가

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 🔗 관련 이슈
- Closes #22 