### PR TITLE
feat: 홈 게시물 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/common/util/CursorCodec.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/util/CursorCodec.java
@@ -1,4 +1,4 @@
-package com.hogu.am_i_hogu.common.pagination;
+package com.hogu.am_i_hogu.common.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
@@ -1,13 +1,16 @@
 package com.hogu.am_i_hogu.domain.post.controller;
 
+import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostCreateRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostUpdateRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
+import com.hogu.am_i_hogu.domain.post.dto.response.HomePostListResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostBookmarkResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostCreateResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostUpdateResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
+import com.hogu.am_i_hogu.domain.post.service.HomePostQueryService;
 import com.hogu.am_i_hogu.domain.post.service.PostBookmarkService;
 import com.hogu.am_i_hogu.domain.post.service.PostCreateService;
 import com.hogu.am_i_hogu.domain.post.service.PostDeleteService;
@@ -30,6 +33,18 @@ public class PostController {
     private final PostDeleteService postDeleteService;
     private final PostBookmarkService postBookmarkService;
     private final PostVoteService postVoteService;
+    private final HomePostQueryService homePostQueryService;
+
+    @GetMapping
+    public ResponseEntity<HomePostListResponse> getHomePosts(
+            Authentication authentication,
+            @ModelAttribute HomePostSearchRequest request
+    ) {
+        Long viewerUserId = authentication == null ? null : Long.valueOf(authentication.getName());
+        HomePostListResponse response = homePostQueryService.getHomePosts(viewerUserId, request);
+
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> getPostById(@PathVariable Long postId, Authentication authentication) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/HomePostCursor.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/HomePostCursor.java
@@ -1,0 +1,13 @@
+package com.hogu.am_i_hogu.domain.post.dto;
+
+import java.time.LocalDateTime;
+
+public record HomePostCursor(
+        String sortBy,
+        Long postId,
+        LocalDateTime createdAt,
+        Integer viewCount,
+        Long commentCount,
+        Long totalVoteCount
+) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/HomePostSummary.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/HomePostSummary.java
@@ -1,0 +1,19 @@
+package com.hogu.am_i_hogu.domain.post.dto;
+
+import java.time.LocalDateTime;
+
+public record HomePostSummary(
+        Long postId,
+        boolean bookmarked,
+        String category,
+        String title,
+        LocalDateTime createdAt,
+        Integer viewCount,
+        String content,
+        String thumbnailUrl,
+        Long totalVoteCount,
+        Long commentCount,
+        String writerNickname,
+        String writerProfileImageUrl
+) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/HomePostSearchRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/HomePostSearchRequest.java
@@ -1,0 +1,10 @@
+package com.hogu.am_i_hogu.domain.post.dto.request;
+
+public record HomePostSearchRequest(
+        String keyword,
+        String categories,
+        String sortBy,
+        Integer pageSize,
+        String cursor
+) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
@@ -1,0 +1,19 @@
+package com.hogu.am_i_hogu.domain.post.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record HomePostItemResponse(
+        Long postId,
+        boolean isBookmarked,
+        List<String> categories,
+        String title,
+        LocalDateTime createdAt,
+        Integer viewCount,
+        String contentPreview,
+        String thumbnailUrl,
+        Long totalVoteCount,
+        Long commentCount,
+        PostWriterResponse writer
+) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import java.util.List;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record HomePostListResponse(
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         Long totalPostCount,
         List<HomePostItemResponse> posts,
         boolean hasNext,

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
@@ -1,0 +1,14 @@
+package com.hogu.am_i_hogu.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record HomePostListResponse(
+        Long totalPostCount,
+        List<HomePostItemResponse> posts,
+        boolean hasNext,
+        String nextCursor
+) {
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/exception/PostErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements ErrorCodeType {
     EMPTY_REQUEST_BODY(HttpStatus.BAD_REQUEST, "EMPTY_REQUEST_BODY"),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE"),
+    INVALID_PARAM_VALUE(HttpStatus.BAD_REQUEST, "INVALID_PARAM_VALUE"),
     INVALID_MYVOTE(HttpStatus.BAD_REQUEST, "INVALID_MYVOTE"),
     WRONG_POSTID_TYPE(HttpStatus.BAD_REQUEST, "WRONG_POSTID_TYPE"),
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_NOT_FOUND"),

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/HomePostQueryRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/HomePostQueryRepository.java
@@ -1,0 +1,214 @@
+package com.hogu.am_i_hogu.domain.post.repository;
+
+import com.hogu.am_i_hogu.domain.post.dto.HomePostCursor;
+import com.hogu.am_i_hogu.domain.post.dto.HomePostSummary;
+import com.hogu.am_i_hogu.domain.post.service.HomePostSortBy;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Repository
+public class HomePostQueryRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public HomePostQueryRepository(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    /**
+     * 홈 화면 게시물 목록을 조회한다.
+     * 게시물 기본 정보와 작성자, 썸네일, 투표 수, 댓글 수, 북마크 여부를 함께 조회한다.
+     */
+    public List<HomePostSummary> findHomePosts(
+            Long viewerUserId,
+            String keyword,
+            List<String> categoryCodes,
+            HomePostSortBy sortBy,
+            HomePostCursor cursor,
+            int limit
+    ) {
+        MapSqlParameterSource params = createBaseParams(viewerUserId, keyword, categoryCodes);
+        params.addValue("limit", limit);
+        addCursorParams(params, cursor);
+
+        String sql = """
+                SELECT hp.*
+                FROM (
+                    -- 홈 목록 카드에 필요한 게시물, 작성자, 집계 정보를 한 번에 만든다.
+                    SELECT
+                        p.id AS post_id,
+                        -- 비회원은 항상 false, 회원은 북마크 row 존재 여부로 계산한다.
+                        CASE
+                            WHEN :viewerUserId IS NULL THEN FALSE
+                            ELSE EXISTS (
+                                SELECT 1
+                                FROM post_bookmarks pb
+                                WHERE pb.post_id = p.id
+                                  AND pb.user_id = :viewerUserId
+                            )
+                        -- CASE 결과를 is_bookmarked로 반환
+                        END AS is_bookmarked,
+                        p.category_code,
+                        p.title,
+                        p.created_at,
+                        p.view_count,
+                        p.content,
+                        -- 게시물 이미지 중 썸네일로 지정된 이미지 URL만 홈 카드에 노출한다.
+                        thumbnail.url AS thumbnail_url,
+                        -- 투표/댓글이 없는 게시물은 집계 서브쿼리 결과가 없으므로 0으로 보정한다.
+                        COALESCE(votes.total_vote_count, 0) AS total_vote_count,
+                        COALESCE(comments.comment_count, 0) AS comment_count,
+                        u.nickname AS writer_nickname,
+                        u.profile_image_url AS writer_profile_image_url
+                    FROM posts p
+                    JOIN users u ON u.id = p.writer_user_id
+                    LEFT JOIN image_assets thumbnail
+                        ON thumbnail.post_id = p.id
+                       AND thumbnail.is_thumbnail = TRUE
+                    -- NONE은 투표 취소 상태이므로 참여 수에서 제외한다.
+                    LEFT JOIN (
+                        SELECT post_id, COUNT(*) AS total_vote_count
+                        FROM post_votes
+                        WHERE my_vote IN ('HOGU', 'NOT_HOGU')
+                        GROUP BY post_id
+                    ) votes ON votes.post_id = p.id
+                    -- 삭제되지 않은 댓글만 홈 목록 댓글 수로 계산한다.
+                    LEFT JOIN (
+                        SELECT post_id, COUNT(*) AS comment_count
+                        FROM comments
+                        WHERE is_deleted = FALSE
+                        GROUP BY post_id
+                    ) comments ON comments.post_id = p.id
+                    -- soft delete된 게시물은 홈 목록에 노출하지 않는다.
+                    WHERE p.is_deleted = FALSE
+                ) hp
+                -- keyword가 없으면 전체 조회, 있으면 제목 포함 검색을 수행한다.
+                WHERE (:keyword IS NULL OR hp.title LIKE CONCAT('%', :keyword, '%'))
+                """;
+
+        sql += categoryFilterSql(categoryCodes);
+        sql += cursorFilterSql(sortBy, cursor);
+        sql += sortBy.orderBySql();
+        sql += " LIMIT :limit";
+
+        return jdbcTemplate.query(sql, params, (rs, rowNum) -> new HomePostSummary(
+                rs.getLong("post_id"),
+                rs.getBoolean("is_bookmarked"),
+                rs.getString("category_code"),
+                rs.getString("title"),
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getInt("view_count"),
+                rs.getString("content"),
+                rs.getString("thumbnail_url"),
+                rs.getLong("total_vote_count"),
+                rs.getLong("comment_count"),
+                rs.getString("writer_nickname"),
+                rs.getString("writer_profile_image_url")
+        ));
+    }
+
+    /**
+     * 카테고리 필터가 적용된 홈 목록의 전체 게시물 수를 조회한다.
+     * 목록 카드에 필요한 조인과 집계는 제외하고, 필터 조건에 맞는 게시물 수만 계산한다.
+     */
+    public long countHomePosts(String keyword, List<String> categoryCodes) {
+        MapSqlParameterSource params = createBaseParams(null, keyword, categoryCodes);
+        String sql = """
+                -- 카테고리 필터 시 totalPostCount로 내려줄 게시물 개수를 계산한다.
+                SELECT COUNT(*)
+                FROM posts p
+                -- 삭제된 게시물은 홈 목록과 totalPostCount 모두에서 제외한다.
+                WHERE p.is_deleted = FALSE
+                  -- keyword가 없으면 전체 조회, 있으면 제목 포함 검색을 수행한다.
+                  AND (:keyword IS NULL OR p.title LIKE CONCAT('%', :keyword, '%'))
+                """;
+        sql += categoryFilterSql(categoryCodes).replace("hp.category_code", "p.category_code");
+
+        Long count = jdbcTemplate.queryForObject(sql, params, Long.class);
+        return count == null ? 0L : count;
+    }
+
+    /**
+     * 동적 SQL에서 공통으로 사용하는 named parameter를 생성한다.
+     * 카테고리 조건이 없을 때는 IN 절 파라미터를 추가하지 않는다.
+     */
+    private MapSqlParameterSource createBaseParams(Long viewerUserId, String keyword, List<String> categoryCodes) {
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("viewerUserId", viewerUserId)
+                .addValue("keyword", keyword);
+        if (!categoryCodes.isEmpty()) {
+            params.addValue("categoryCodes", categoryCodes);
+        }
+        return params;
+    }
+
+    /**
+     * 카테고리 필터가 있을 때만 IN 절 SQL을 반환한다.
+     * 빈 목록이면 전체 카테고리를 조회해야 하므로 아무 조건도 추가하지 않는다.
+     */
+    private String categoryFilterSql(List<String> categoryCodes) {
+        if (categoryCodes.isEmpty()) {
+            return "";
+        }
+        return " AND hp.category_code IN (:categoryCodes)\n";
+    }
+
+    /**
+     * cursor 기반 페이지네이션에 필요한 기준값을 SQL 파라미터에 추가한다.
+     * 정렬 기준에 따라 필요한 값이 다르지만, cursor가 있으면 모든 기준값을 함께 등록한다.
+     */
+    private void addCursorParams(MapSqlParameterSource params, HomePostCursor cursor) {
+        if (cursor == null) {
+            return;
+        }
+        params.addValue("cursorPostId", cursor.postId());
+        params.addValue("cursorCreatedAt", Timestamp.valueOf(cursor.createdAt()));
+        params.addValue("cursorViewCount", cursor.viewCount());
+        params.addValue("cursorCommentCount", cursor.commentCount());
+        params.addValue("cursorTotalVoteCount", cursor.totalVoteCount());
+    }
+
+    /**
+     * 현재 정렬 기준과 cursor를 이용해 다음 페이지 조건 SQL을 만든다.
+     * 모든 정렬은 동점 상황에서 postId 내림차순으로 이어지도록 보조 조건을 둔다.
+     */
+    private String cursorFilterSql(HomePostSortBy sortBy, HomePostCursor cursor) {
+        if (cursor == null) {
+            return "";
+        }
+        return switch (sortBy) {
+            case LATEST -> """
+                     -- 최신순: 이전 페이지 마지막 게시물보다 오래된 게시물을 조회한다.
+                     AND (
+                         hp.created_at < :cursorCreatedAt
+                         OR (hp.created_at = :cursorCreatedAt AND hp.post_id < :cursorPostId)
+                     )
+                    """;
+            case MOST_VIEWED -> """
+                     -- 조회수순: 조회수가 더 낮거나, 동점이면 postId가 더 작은 게시물을 조회한다.
+                     AND (
+                         hp.view_count < :cursorViewCount
+                         OR (hp.view_count = :cursorViewCount AND hp.post_id < :cursorPostId)
+                     )
+                    """;
+            case MOST_COMMENTED -> """
+                     -- 댓글수순: 댓글 수가 더 적거나, 동점이면 postId가 더 작은 게시물을 조회한다.
+                     AND (
+                         hp.comment_count < :cursorCommentCount
+                         OR (hp.comment_count = :cursorCommentCount AND hp.post_id < :cursorPostId)
+                     )
+                    """;
+            case MOST_PARTICIPATED -> """
+                     -- 참여수순: 투표 참여 수가 더 적거나, 동점이면 postId가 더 작은 게시물을 조회한다.
+                     AND (
+                         hp.total_vote_count < :cursorTotalVoteCount
+                         OR (hp.total_vote_count = :cursorTotalVoteCount AND hp.post_id < :cursorPostId)
+                     )
+                    """;
+        };
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
@@ -2,7 +2,7 @@ package com.hogu.am_i_hogu.domain.post.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
 import com.hogu.am_i_hogu.domain.post.dto.HomePostCursor;
 import com.hogu.am_i_hogu.domain.post.dto.HomePostSummary;
 import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
@@ -50,13 +50,12 @@ public class HomePostQueryService {
         List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
         String keyword = normalizeKeyword(request.keyword(), errors);
         List<String> categoryCodes = normalizeCategories(request.categories(), errors);
+        int errorCountBeforeSortBy = errors.size();
         HomePostSortBy sortBy = normalizeSortBy(request.sortBy(), errors);
+        boolean sortByIsValid = errors.size() == errorCountBeforeSortBy;
         int pageSize = normalizePageSize(request.pageSize());
 
-        HomePostCursor cursor = null;
-        if (errors.isEmpty()) {
-            cursor = decodeCursor(request.cursor(), sortBy, errors);
-        }
+        HomePostCursor cursor = decodeCursor(request.cursor(), sortBy, sortByIsValid, errors);
         if (!errors.isEmpty()) {
             throw new CustomException(PostErrorCode.INVALID_PARAM_VALUE, errors);
         }
@@ -171,17 +170,28 @@ public class HomePostQueryService {
      * 요청 cursor를 디코딩하고 현재 정렬 기준과 호환되는지 검증한다.
      * cursor 형식이 잘못됐거나 정렬 기준이 다르면 cursor 필드 오류를 추가한다.
      */
-    private HomePostCursor decodeCursor(String rawCursor, HomePostSortBy sortBy, List<ErrorResponse.ErrorDetail> errors) {
+    private HomePostCursor decodeCursor(
+            String rawCursor,
+            HomePostSortBy sortBy,
+            boolean sortByIsValid,
+            List<ErrorResponse.ErrorDetail> errors
+    ) {
         if (rawCursor == null || rawCursor.isBlank()) {
             return null;
         }
         try {
             HomePostCursor cursor = cursorCodec.decode(rawCursor, HomePostCursor.class);
-            if (cursor.postId() == null || cursor.createdAt() == null || !sortBy.name().equals(cursor.sortBy())) {
+            if (cursor.postId() == null || cursor.createdAt() == null) {
                 errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));
                 return null;
             }
-            validateSortValue(sortBy, cursor, errors);
+            if (sortByIsValid && !sortBy.name().equals(cursor.sortBy())) {
+                errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));
+                return null;
+            }
+            if (sortByIsValid) {
+                validateSortValue(sortBy, cursor, errors);
+            }
             return errors.isEmpty() ? cursor : null;
         } catch (IllegalStateException e) {
             errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryService.java
@@ -1,0 +1,275 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.common.pagination.CursorCodec;
+import com.hogu.am_i_hogu.domain.post.dto.HomePostCursor;
+import com.hogu.am_i_hogu.domain.post.dto.HomePostSummary;
+import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;
+import com.hogu.am_i_hogu.domain.post.dto.response.HomePostItemResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.HomePostListResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostWriterResponse;
+import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
+import com.hogu.am_i_hogu.domain.post.repository.HomePostQueryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Service
+public class HomePostQueryService {
+
+    private static final int DEFAULT_PAGE_SIZE = 5;
+    private static final int MAX_PAGE_SIZE = 15;
+    private static final int CONTENT_PREVIEW_LENGTH = 100;
+    private static final String ALL_CATEGORY = "ALL";
+
+    private final CursorCodec cursorCodec;
+    private final CategoryRepository categoryRepository;
+    private final HomePostQueryRepository homePostQueryRepository;
+
+    public HomePostQueryService(
+            CursorCodec cursorCodec,
+            CategoryRepository categoryRepository,
+            HomePostQueryRepository homePostQueryRepository
+    ) {
+        this.cursorCodec = cursorCodec;
+        this.categoryRepository = categoryRepository;
+        this.homePostQueryRepository = homePostQueryRepository;
+    }
+
+    /**
+     * 홈 화면 게시물 목록을 조회한다.
+     * 요청 파라미터를 검증하고, pageSize보다 1개 더 조회해 다음 페이지 존재 여부를 계산한다.
+     */
+    public HomePostListResponse getHomePosts(Long viewerUserId, HomePostSearchRequest request) {
+        List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
+        String keyword = normalizeKeyword(request.keyword(), errors);
+        List<String> categoryCodes = normalizeCategories(request.categories(), errors);
+        HomePostSortBy sortBy = normalizeSortBy(request.sortBy(), errors);
+        int pageSize = normalizePageSize(request.pageSize());
+
+        HomePostCursor cursor = null;
+        if (errors.isEmpty()) {
+            cursor = decodeCursor(request.cursor(), sortBy, errors);
+        }
+        if (!errors.isEmpty()) {
+            throw new CustomException(PostErrorCode.INVALID_PARAM_VALUE, errors);
+        }
+
+        List<HomePostSummary> queriedPosts = homePostQueryRepository.findHomePosts(
+                viewerUserId,
+                keyword,
+                categoryCodes,
+                sortBy,
+                cursor,
+                pageSize + 1
+        );
+        boolean hasNext = queriedPosts.size() > pageSize;
+        List<HomePostSummary> summaries = hasNext
+                ? queriedPosts.subList(0, pageSize)
+                : queriedPosts;
+
+        Long totalPostCount = shouldReturnTotalPostCount(request.categories(), categoryCodes)
+                ? homePostQueryRepository.countHomePosts(keyword, categoryCodes)
+                : null;
+
+        return new HomePostListResponse(
+                totalPostCount,
+                mapToResponses(summaries),
+                hasNext,
+                createNextCursor(hasNext, summaries, sortBy)
+        );
+    }
+
+    /**
+     * 검색어를 정리한다.
+     * 검색어가 생략되면 null을 반환하고, 공백뿐이면 keyword 필드 오류를 추가한다.
+     */
+    private String normalizeKeyword(String rawKeyword, List<ErrorResponse.ErrorDetail> errors) {
+        if (rawKeyword == null) {
+            return null;
+        }
+        String keyword = rawKeyword.trim();
+        if (keyword.isEmpty()) {
+            errors.add(new ErrorResponse.ErrorDetail("keyword", "EMPTY_KEYWORD"));
+            return null;
+        }
+        return keyword;
+    }
+
+    /**
+     * comma-separated 카테고리 파라미터를 DB 카테고리 코드 목록으로 변환한다.
+     * 생략되거나 ALL이면 전체 카테고리 조회로 보고 빈 목록을 반환한다.
+     */
+    private List<String> normalizeCategories(String rawCategories, List<ErrorResponse.ErrorDetail> errors) {
+        if (rawCategories == null || rawCategories.isBlank()) {
+            return List.of();
+        }
+
+        String[] tokens = rawCategories.split(",");
+        Set<String> categoryCodes = new LinkedHashSet<>();
+        for (String token : tokens) {
+            String category = token.trim().toUpperCase(Locale.ROOT);
+            if (category.isEmpty()) {
+                errors.add(new ErrorResponse.ErrorDetail("categories", "INVALID_CATEGORIES"));
+                return List.of();
+            }
+            if (ALL_CATEGORY.equals(category)) {
+                return List.of();
+            }
+            categoryCodes.add(category);
+        }
+
+        if (categoryCodes.isEmpty()) {
+            return List.of();
+        }
+        long foundCount = categoryRepository.findAllById(categoryCodes).size();
+        if (foundCount != categoryCodes.size()) {
+            errors.add(new ErrorResponse.ErrorDetail("categories", "INVALID_CATEGORIES"));
+            return List.of();
+        }
+        return List.copyOf(categoryCodes);
+    }
+
+    /**
+     * 정렬 파라미터를 홈 목록 정렬 enum으로 변환한다.
+     * 생략되면 최신순을 기본값으로 사용하고, 복수 값이나 미지원 값은 필드 오류로 기록한다.
+     */
+    private HomePostSortBy normalizeSortBy(String rawSortBy, List<ErrorResponse.ErrorDetail> errors) {
+        if (rawSortBy == null || rawSortBy.isBlank()) {
+            return HomePostSortBy.LATEST;
+        }
+        if (rawSortBy.contains(",")) {
+            errors.add(new ErrorResponse.ErrorDetail("sortBy", "MULTIPLE_SORTING"));
+            return HomePostSortBy.LATEST;
+        }
+        try {
+            return HomePostSortBy.valueOf(rawSortBy.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            errors.add(new ErrorResponse.ErrorDetail("sortBy", "INVALID_SORTING"));
+            return HomePostSortBy.LATEST;
+        }
+    }
+
+    /**
+     * pageSize를 서비스 정책 범위로 보정한다.
+     * 값이 없거나 1보다 작으면 기본값을 사용하고, 최대값을 넘으면 최대값으로 제한한다.
+     */
+    private int normalizePageSize(Integer pageSize) {
+        if (pageSize == null || pageSize < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(pageSize, MAX_PAGE_SIZE);
+    }
+
+    /**
+     * 요청 cursor를 디코딩하고 현재 정렬 기준과 호환되는지 검증한다.
+     * cursor 형식이 잘못됐거나 정렬 기준이 다르면 cursor 필드 오류를 추가한다.
+     */
+    private HomePostCursor decodeCursor(String rawCursor, HomePostSortBy sortBy, List<ErrorResponse.ErrorDetail> errors) {
+        if (rawCursor == null || rawCursor.isBlank()) {
+            return null;
+        }
+        try {
+            HomePostCursor cursor = cursorCodec.decode(rawCursor, HomePostCursor.class);
+            if (cursor.postId() == null || cursor.createdAt() == null || !sortBy.name().equals(cursor.sortBy())) {
+                errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));
+                return null;
+            }
+            validateSortValue(sortBy, cursor, errors);
+            return errors.isEmpty() ? cursor : null;
+        } catch (IllegalStateException e) {
+            errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));
+            return null;
+        }
+    }
+
+    /**
+     * 정렬 기준별 cursor 필수 값을 검증한다.
+     * 최신순은 생성 시각과 postId만 필요하고, 나머지 정렬은 각 정렬값이 추가로 필요하다.
+     */
+    private void validateSortValue(
+            HomePostSortBy sortBy,
+            HomePostCursor cursor,
+            List<ErrorResponse.ErrorDetail> errors
+    ) {
+        boolean invalid = switch (sortBy) {
+            case LATEST -> false;
+            case MOST_VIEWED -> cursor.viewCount() == null;
+            case MOST_COMMENTED -> cursor.commentCount() == null;
+            case MOST_PARTICIPATED -> cursor.totalVoteCount() == null;
+        };
+        if (invalid) {
+            errors.add(new ErrorResponse.ErrorDetail("cursor", "INVALID_CURSOR"));
+        }
+    }
+
+    /**
+     * totalPostCount를 응답에 포함할지 판단한다.
+     * 명세 기준으로 카테고리 필터가 실제 적용된 경우에만 전체 개수를 반환한다.
+     */
+    private boolean shouldReturnTotalPostCount(String rawCategories, List<String> categoryCodes) {
+        return rawCategories != null && !rawCategories.isBlank() && !categoryCodes.isEmpty();
+    }
+
+    /**
+     * repository 조회 결과를 API 응답 DTO로 변환한다.
+     * 단일 카테고리 정책을 유지하되, 응답 형식은 categories 배열로 맞춘다.
+     */
+    private List<HomePostItemResponse> mapToResponses(List<HomePostSummary> summaries) {
+        return summaries.stream()
+                .map(summary -> new HomePostItemResponse(
+                        summary.postId(),
+                        summary.bookmarked(),
+                        List.of(summary.category()),
+                        summary.title(),
+                        summary.createdAt(),
+                        summary.viewCount(),
+                        toContentPreview(summary.content()),
+                        summary.thumbnailUrl(),
+                        summary.totalVoteCount(),
+                        summary.commentCount(),
+                        new PostWriterResponse(
+                                summary.writerNickname(),
+                                summary.writerProfileImageUrl()
+                        )
+                ))
+                .toList();
+    }
+
+    /**
+     * 본문 미리보기를 만든다.
+     * 100자 이하면 원문을 그대로 사용하고, 넘으면 앞 100자만 반환한다.
+     */
+    private String toContentPreview(String content) {
+        if (content.length() <= CONTENT_PREVIEW_LENGTH) {
+            return content;
+        }
+        return content.substring(0, CONTENT_PREVIEW_LENGTH);
+    }
+
+    /**
+     * 다음 페이지 요청에 사용할 cursor를 생성한다.
+     * 다음 페이지가 없거나 응답 게시물이 없으면 null을 반환한다.
+     */
+    private String createNextCursor(boolean hasNext, List<HomePostSummary> summaries, HomePostSortBy sortBy) {
+        if (!hasNext || summaries.isEmpty()) {
+            return null;
+        }
+
+        HomePostSummary last = summaries.get(summaries.size() - 1);
+        return cursorCodec.encode(new HomePostCursor(
+                sortBy.name(),
+                last.postId(),
+                last.createdAt(),
+                last.viewCount(),
+                last.commentCount(),
+                last.totalVoteCount()
+        ));
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostSortBy.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/HomePostSortBy.java
@@ -1,0 +1,18 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+public enum HomePostSortBy {
+    LATEST(" ORDER BY hp.created_at DESC, hp.post_id DESC"),
+    MOST_VIEWED(" ORDER BY hp.view_count DESC, hp.post_id DESC"),
+    MOST_COMMENTED(" ORDER BY hp.comment_count DESC, hp.post_id DESC"),
+    MOST_PARTICIPATED(" ORDER BY hp.total_vote_count DESC, hp.post_id DESC");
+
+    private final String orderBySql;
+
+    HomePostSortBy(String orderBySql) {
+        this.orderBySql = orderBySql;
+    }
+
+    public String orderBySql() {
+        return orderBySql;
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserController.java
@@ -1,6 +1,6 @@
 package com.hogu.am_i_hogu.domain.user.controller;
 
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.user.dto.request.UpdateProfileRequest;
 import com.hogu.am_i_hogu.domain.user.dto.response.*;
 import com.hogu.am_i_hogu.domain.user.service.*;

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/CursorRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/CursorRequest.java
@@ -1,4 +1,4 @@
-package com.hogu.am_i_hogu.common.pagination;
+package com.hogu.am_i_hogu.domain.user.dto.request;
 
 public record CursorRequest(
         Integer pageSize,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyBookmarkQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyBookmarkQueryService.java
@@ -2,8 +2,8 @@ package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.dto.PostCommentCount;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyCommentQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyCommentQueryService.java
@@ -2,8 +2,8 @@ package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.comment.dto.PostCommentCount;
 import com.hogu.am_i_hogu.domain.user.dto.MyCommentCursor;

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyPostQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyPostQueryService.java
@@ -2,8 +2,8 @@ package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.dto.PostCommentCount;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyVoteQueryService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/MyVoteQueryService.java
@@ -2,8 +2,8 @@ package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.dto.PostCommentCount;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;

--- a/src/test/java/com/hogu/am_i_hogu/common/pagination/CursorCodecTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/pagination/CursorCodecTest.java
@@ -2,6 +2,7 @@ package com.hogu.am_i_hogu.common.pagination;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
 import com.hogu.am_i_hogu.domain.user.dto.MyPostCursor;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/hogu/am_i_hogu/common/util/CursorCodecTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/util/CursorCodecTest.java
@@ -1,8 +1,7 @@
-package com.hogu.am_i_hogu.common.pagination;
+package com.hogu.am_i_hogu.common.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.hogu.am_i_hogu.common.util.CursorCodec;
 import com.hogu.am_i_hogu.domain.user.dto.MyPostCursor;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -260,7 +260,8 @@ class PostControllerTest {
         mockMvc.perform(get("/api/posts")
                         .param("keyword", "   ")
                         .param("categories", "UNKNOWN")
-                        .param("sortBy", "LATEST,MOST_VIEWED"))
+                        .param("sortBy", "LATEST,MOST_VIEWED")
+                        .param("cursor", "invalid-cursor"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_PARAM_VALUE"))
                 .andExpect(jsonPath("$.errors[0].field").value("keyword"))
@@ -268,7 +269,9 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.errors[1].field").value("categories"))
                 .andExpect(jsonPath("$.errors[1].code").value("INVALID_CATEGORIES"))
                 .andExpect(jsonPath("$.errors[2].field").value("sortBy"))
-                .andExpect(jsonPath("$.errors[2].code").value("MULTIPLE_SORTING"));
+                .andExpect(jsonPath("$.errors[2].code").value("MULTIPLE_SORTING"))
+                .andExpect(jsonPath("$.errors[3].field").value("cursor"))
+                .andExpect(jsonPath("$.errors[3].code").value("INVALID_CURSOR"));
     }
 
     // 실패 케이스: 존재하지 않는 정렬 기준과 해석 불가능한 cursor는 필드별 오류 코드를 반환한다.

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -72,6 +72,7 @@ class PostControllerTest {
         jdbcTemplate.update("DELETE FROM post_bookmarks");
         jdbcTemplate.update("DELETE FROM post_votes");
         jdbcTemplate.update("DELETE FROM image_assets");
+        jdbcTemplate.update("DELETE FROM comments");
         jdbcTemplate.update("DELETE FROM posts");
         jdbcTemplate.update("DELETE FROM user_hogu_stats");
         jdbcTemplate.update("DELETE FROM users");
@@ -92,6 +93,199 @@ class PostControllerTest {
                 now,
                 now
         );
+    }
+
+    // 정상 케이스: 비회원도 홈 게시물 목록을 조회할 수 있고, 삭제된 글은 제외된다.
+    @Test
+    void getHomePostsAsGuestReturnsVisiblePostsOnly() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        LocalDateTime older = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        LocalDateTime newer = LocalDateTime.of(2026, 5, 1, 11, 0, 0);
+        insertPost(100L, TEST_USER_ID, "USED_TRADE", "오래된 글", "오래된 본문입니다", false, older);
+        insertPost(101L, TEST_USER_ID, "CONTRACT", "최신 글", "최신 본문입니다", false, newer);
+        insertPost(102L, TEST_USER_ID, "USED_TRADE", "삭제된 글", "삭제된 본문입니다", true, newer);
+        insertImage(1001L, 101L, "https://example.com/thumbnail.jpg", true, 0, newer);
+        mockMvc.perform(get("/api/posts"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalPostCount").doesNotExist())
+                .andExpect(jsonPath("$.posts.length()").value(2))
+                .andExpect(jsonPath("$.posts[0].postId").value(101L))
+                .andExpect(jsonPath("$.posts[0].isBookmarked").value(false))
+                .andExpect(jsonPath("$.posts[0].categories[0]").value("CONTRACT"))
+                .andExpect(jsonPath("$.posts[0].title").value("최신 글"))
+                .andExpect(jsonPath("$.posts[0].contentPreview").value("최신 본문입니다"))
+                .andExpect(jsonPath("$.posts[0].thumbnailUrl").value("https://example.com/thumbnail.jpg"))
+                .andExpect(jsonPath("$.posts[0].totalVoteCount").value(0))
+                .andExpect(jsonPath("$.posts[0].commentCount").value(0))
+                .andExpect(jsonPath("$.posts[0].writer.nickname").value("hogu"))
+                .andExpect(jsonPath("$.posts[1].postId").value(100L))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.nextCursor").doesNotExist());
+    }
+
+    // 정상 케이스: 로그인 사용자의 북마크 여부를 홈 게시물 목록에 반영한다.
+    @Test
+    void getHomePostsAsAuthenticatedUserReturnsBookmarkStatus() throws Exception {
+        stubAuthenticatedUser();
+        Long otherUserId = 2L;
+        LocalDateTime now = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        insertUser(otherUserId, "other-hogu", now);
+        insertPost(100L, otherUserId, "USED_TRADE", "북마크한 글", "본문입니다", false, now);
+        insertPost(101L, otherUserId, "USED_TRADE", "북마크 안 한 글", "본문입니다", false, now.plusMinutes(1));
+        insertPostBookmark(TEST_USER_ID, 100L, now);
+        mockMvc.perform(get("/api/posts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postId").value(101L))
+                .andExpect(jsonPath("$.posts[0].isBookmarked").value(false))
+                .andExpect(jsonPath("$.posts[1].postId").value(100L))
+                .andExpect(jsonPath("$.posts[1].isBookmarked").value(true));
+    }
+
+    // 정상 케이스: keyword와 categories로 필터링하고 카테고리 필터가 있으면 totalPostCount를 반환한다.
+    @Test
+    void getHomePostsFiltersByKeywordAndCategories() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        insertPost(100L, TEST_USER_ID, "USED_TRADE", "아이폰 거래", "본문입니다", false, now);
+        insertPost(101L, TEST_USER_ID, "PURCHASE", "아이폰 구매", "본문입니다", false, now.plusMinutes(1));
+        insertPost(102L, TEST_USER_ID, "WORK", "아이폰 업무", "본문입니다", false, now.plusMinutes(2));
+        mockMvc.perform(get("/api/posts")
+                        .param("keyword", "아이폰")
+                        .param("categories", "USED_TRADE,PURCHASE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalPostCount").value(2))
+                .andExpect(jsonPath("$.posts.length()").value(2))
+                .andExpect(jsonPath("$.posts[0].postId").value(101L))
+                .andExpect(jsonPath("$.posts[1].postId").value(100L));
+    }
+
+    // 정상 케이스: 댓글 수와 투표 참여 수 기준 정렬을 지원한다.
+    @Test
+    void getHomePostsSortsByCommentCountAndVoteParticipation() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        insertUser(2L, "commenter", now);
+        insertUser(3L, "voter", now);
+        insertPost(100L, TEST_USER_ID, "USED_TRADE", "댓글 적은 글", "본문입니다", false, now);
+        insertPost(101L, TEST_USER_ID, "USED_TRADE", "댓글 많은 글", "본문입니다", false, now.plusMinutes(1));
+        insertPost(102L, TEST_USER_ID, "USED_TRADE", "투표 많은 글", "본문입니다", false, now.plusMinutes(2));
+        insertComment(1000L, 101L, 2L, "댓글 1", now);
+        insertComment(1001L, 101L, 2L, "댓글 2", now.plusSeconds(1));
+        insertPostVote(2L, 102L, "HOGU", now);
+        insertPostVote(3L, 102L, "NOT_HOGU", now.plusSeconds(1));
+        insertPostVote(TEST_USER_ID, 100L, "NONE", now.plusSeconds(2));
+        mockMvc.perform(get("/api/posts")
+                        .param("sortBy", "MOST_COMMENTED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postId").value(101L))
+                .andExpect(jsonPath("$.posts[0].commentCount").value(2));
+        mockMvc.perform(get("/api/posts")
+                        .param("sortBy", "MOST_PARTICIPATED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postId").value(102L))
+                .andExpect(jsonPath("$.posts[0].totalVoteCount").value(2));
+    }
+
+    // 정상 케이스: 조회수 기준 정렬을 지원하고 동점이면 postId 내림차순으로 정렬한다.
+    @Test
+    void getHomePostsSortsByViewCount() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        LocalDateTime now = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        insertPost(100L, TEST_USER_ID, "USED_TRADE", "조회수 낮은 글", "본문입니다", false, now);
+        insertPost(101L, TEST_USER_ID, "USED_TRADE", "조회수 높은 글", "본문입니다", false, now.plusMinutes(1));
+        insertPost(102L, TEST_USER_ID, "USED_TRADE", "조회수 동점 글", "본문입니다", false, now.plusMinutes(2));
+        jdbcTemplate.update("UPDATE posts SET view_count = ? WHERE id = ?", 1, 100L);
+        jdbcTemplate.update("UPDATE posts SET view_count = ? WHERE id = ?", 10, 101L);
+        jdbcTemplate.update("UPDATE posts SET view_count = ? WHERE id = ?", 10, 102L);
+        mockMvc.perform(get("/api/posts")
+                        .param("sortBy", "MOST_VIEWED"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts[0].postId").value(102L))
+                .andExpect(jsonPath("$.posts[1].postId").value(101L))
+                .andExpect(jsonPath("$.posts[2].postId").value(100L));
+    }
+
+    // 정상 케이스: pageSize와 nextCursor로 다음 페이지를 중복 없이 조회한다.
+    @Test
+    void getHomePostsReturnsNextPageWithCursor() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        LocalDateTime base = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+        for (long postId = 100L; postId <= 105L; postId++) {
+            insertPost(
+                    postId,
+                    TEST_USER_ID,
+                    "USED_TRADE",
+                    "글 " + postId,
+                    "본문입니다",
+                    false,
+                    base.plusMinutes(postId - 100L)
+            );
+        }
+        String response = mockMvc.perform(get("/api/posts")
+                        .param("pageSize", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts.length()").value(5))
+                .andExpect(jsonPath("$.posts[0].postId").value(105L))
+                .andExpect(jsonPath("$.posts[4].postId").value(101L))
+                .andExpect(jsonPath("$.hasNext").value(true))
+                .andExpect(jsonPath("$.nextCursor").isString())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String nextCursor = com.jayway.jsonpath.JsonPath.read(response, "$.nextCursor");
+        mockMvc.perform(get("/api/posts")
+                        .param("pageSize", "5")
+                        .param("cursor", nextCursor))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.posts.length()").value(1))
+                .andExpect(jsonPath("$.posts[0].postId").value(100L))
+                .andExpect(jsonPath("$.hasNext").value(false))
+                .andExpect(jsonPath("$.nextCursor").doesNotExist());
+    }
+
+    // 실패 케이스: 잘못된 홈 조회 파라미터는 필드별 오류 코드를 반환한다.
+    @Test
+    void getHomePostsRejectsInvalidQueryParams() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        mockMvc.perform(get("/api/posts")
+                        .param("keyword", "   ")
+                        .param("categories", "UNKNOWN")
+                        .param("sortBy", "LATEST,MOST_VIEWED"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PARAM_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("keyword"))
+                .andExpect(jsonPath("$.errors[0].code").value("EMPTY_KEYWORD"))
+                .andExpect(jsonPath("$.errors[1].field").value("categories"))
+                .andExpect(jsonPath("$.errors[1].code").value("INVALID_CATEGORIES"))
+                .andExpect(jsonPath("$.errors[2].field").value("sortBy"))
+                .andExpect(jsonPath("$.errors[2].code").value("MULTIPLE_SORTING"));
+    }
+
+    // 실패 케이스: 존재하지 않는 정렬 기준과 해석 불가능한 cursor는 필드별 오류 코드를 반환한다.
+    @Test
+    void getHomePostsRejectsInvalidSortByAndCursor() throws Exception {
+        when(jwtProvider.validateAccessToken(null))
+                .thenReturn(JwtProvider.TokenValidationResult.EMPTY);
+        mockMvc.perform(get("/api/posts")
+                        .param("sortBy", "UNKNOWN"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PARAM_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("sortBy"))
+                .andExpect(jsonPath("$.errors[0].code").value("INVALID_SORTING"));
+        mockMvc.perform(get("/api/posts")
+                        .param("cursor", "invalid-cursor"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PARAM_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("cursor"))
+                .andExpect(jsonPath("$.errors[0].code").value("INVALID_CURSOR"));
     }
 
     // 정상 케이스: 인증된 사용자가 필수 값과 이미지 정보를 보내면 게시물이 생성되고 postId를 반환한다.
@@ -1436,6 +1630,27 @@ class PostControllerTest {
                 userId,
                 postId,
                 myVote,
+                now,
+                now
+        );
+    }
+
+    private void insertComment(Long commentId, Long postId, Long writerUserId, String content, LocalDateTime now) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO comments
+                    (id, post_id, writer_user_id, parent_comment_id, depth, content, is_deleted, deleted_at, created_at, updated_at)
+                VALUES
+                    (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                commentId,
+                postId,
+                writerUserId,
+                null,
+                0,
+                content,
+                false,
+                null,
                 now,
                 now
         );

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -121,7 +121,8 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.posts[0].writer.nickname").value("hogu"))
                 .andExpect(jsonPath("$.posts[1].postId").value(100L))
                 .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.nextCursor").doesNotExist());
+                .andExpect(result -> assertThat(result.getResponse().getContentAsString())
+                        .contains("\"nextCursor\":null"));
     }
 
     // 정상 케이스: 로그인 사용자의 북마크 여부를 홈 게시물 목록에 반영한다.
@@ -247,7 +248,8 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.posts.length()").value(1))
                 .andExpect(jsonPath("$.posts[0].postId").value(100L))
                 .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.nextCursor").doesNotExist());
+                .andExpect(result -> assertThat(result.getResponse().getContentAsString())
+                        .contains("\"nextCursor\":null"));
     }
 
     // 실패 케이스: 잘못된 홈 조회 파라미터는 필드별 오류 코드를 반환한다.

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
@@ -1,0 +1,105 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.common.pagination.CursorCodec;
+import com.hogu.am_i_hogu.domain.post.dto.HomePostCursor;
+import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;
+import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
+import com.hogu.am_i_hogu.domain.post.repository.HomePostQueryRepository;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class HomePostQueryServiceTest {
+
+    private final CursorCodec cursorCodec = mock(CursorCodec.class);
+    private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
+    private final HomePostQueryRepository homePostQueryRepository = mock(HomePostQueryRepository.class);
+    private final HomePostQueryService homePostQueryService = new HomePostQueryService(
+            cursorCodec,
+            categoryRepository,
+            homePostQueryRepository
+    );
+
+    // 실패 케이스: cursor 디코딩에 실패하면 INVALID_CURSOR를 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWhenCursorIsInvalid() {
+        when(cursorCodec.decode("invalid-cursor", HomePostCursor.class))
+                .thenThrow(new IllegalStateException("Failed to decode cursor"));
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest(null, null, null, 5, "invalid-cursor")
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("cursor");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("INVALID_CURSOR");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+
+    // 실패 케이스: keyword가 공백뿐이면 EMPTY_KEYWORD를 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWhenKeywordIsBlank() {
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest("   ", null, null, 5, null)
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("keyword");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("EMPTY_KEYWORD");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+
+    // 실패 케이스: 존재하지 않는 category면 INVALID_CATEGORIES를 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWhenCategoryDoesNotExist() {
+        when(categoryRepository.findAllById(any()))
+                .thenReturn(List.of());
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest(null, "UNKNOWN", null, 5, null)
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("categories");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("INVALID_CATEGORIES");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+
+    // 실패 케이스: 정의되지 않은 sortBy면 INVALID_SORTING을 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWhenSortByIsInvalid() {
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest(null, null, "UNKNOWN", 5, null)
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("sortBy");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("INVALID_SORTING");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+
+    // 실패 케이스: sortBy가 comma로 여러 개 전달되면 MULTIPLE_SORTING을 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWhenSortByHasMultipleValues() {
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest(null, null, "LATEST,MOST_VIEWED", 5, null)
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("sortBy");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("MULTIPLE_SORTING");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
@@ -1,7 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
 import com.hogu.am_i_hogu.domain.post.dto.HomePostCursor;
 import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/HomePostQueryServiceTest.java
@@ -59,6 +59,24 @@ class HomePostQueryServiceTest {
         verifyNoInteractions(homePostQueryRepository);
     }
 
+    // 실패 케이스: keyword와 cursor가 모두 잘못되면 두 필드 오류를 함께 반환하고 DB 조회를 수행하지 않는다.
+    @Test
+    void getHomePostsThrowsInvalidParamValueWithKeywordAndCursorErrorsTogether() {
+        when(cursorCodec.decode("invalid-cursor", HomePostCursor.class))
+                .thenThrow(new IllegalStateException("Failed to decode cursor"));
+        assertThatThrownBy(() -> homePostQueryService.getHomePosts(
+                null,
+                new HomePostSearchRequest("   ", null, null, 5, "invalid-cursor")
+        )).isInstanceOfSatisfying(CustomException.class, exception -> {
+            assertThat(exception.getErrorCode()).isEqualTo(PostErrorCode.INVALID_PARAM_VALUE);
+            assertThat(exception.getErrors().get(0).getField()).isEqualTo("keyword");
+            assertThat(exception.getErrors().get(0).getCode()).isEqualTo("EMPTY_KEYWORD");
+            assertThat(exception.getErrors().get(1).getField()).isEqualTo("cursor");
+            assertThat(exception.getErrors().get(1).getCode()).isEqualTo("INVALID_CURSOR");
+        });
+        verifyNoInteractions(homePostQueryRepository);
+    }
+
     // 실패 케이스: 존재하지 않는 category면 INVALID_CATEGORIES를 반환하고 DB 조회를 수행하지 않는다.
     @Test
     void getHomePostsThrowsInvalidParamValueWhenCategoryDoesNotExist() {

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyBookmarkQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyBookmarkQueryServiceTest.java
@@ -1,8 +1,8 @@
 package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;
 import com.hogu.am_i_hogu.domain.user.dto.MyBookmarkCursor;

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyCommentQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyCommentQueryServiceTest.java
@@ -1,8 +1,8 @@
 package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.user.dto.MyCommentCursor;
 import com.hogu.am_i_hogu.domain.user.exception.UserErrorCode;

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyPostQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyPostQueryServiceTest.java
@@ -1,8 +1,8 @@
 package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.user.dto.MyPostCursor;

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyVoteQueryServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/service/MyVoteQueryServiceTest.java
@@ -1,8 +1,8 @@
 package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.pagination.CursorCodec;
-import com.hogu.am_i_hogu.common.pagination.CursorRequest;
+import com.hogu.am_i_hogu.common.util.CursorCodec;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.comment.repository.CommentRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
 import com.hogu.am_i_hogu.domain.user.dto.MyVoteCursor;


### PR DESCRIPTION
## 📋 변경 사항

HOME-001 명세에 맞춰 `GET /api/posts` 홈 게시물 목록 조회 API를 구현했습니다.

- 비회원/회원 모두 홈 게시물 목록을 조회할 수 있도록 `PostController`에 `GET /api/posts` 엔드포인트를 추가했습니다.
- 로그인 사용자의 경우 게시물별 `isBookmarked`를 현재 사용자 기준으로 계산하도록 구현했습니다.
- `keyword`, `categories`, `sortBy`, `pageSize`, `cursor` query parameter를 추가했습니다.
- 정렬 기준은 `LATEST`, `MOST_VIEWED`, `MOST_COMMENTED`, `MOST_PARTICIPATED`를 지원합니다.
- 홈 목록 응답 DTO, cursor DTO, query summary DTO를 추가했습니다.
- 게시물 목록 조회용 `HomePostQueryRepository`를 추가해 게시물, 작성자, 썸네일, 댓글 수, 투표 참여 수, 북마크 여부를 한 번에 조회하도록 구현했습니다.
- 잘못된 query parameter 응답을 위해 `INVALID_PARAM_VALUE` 에러 코드를 추가했습니다.

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 링크해주세요 -->

- Closes #45 
