### PR TITLE
feat: AWS S3 이미지 업로드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//S3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/env.example
+++ b/env.example
@@ -12,5 +12,6 @@ TOKEN_ENCRYPTION_SECRET=base64_encoded_token_encryption_secret
 
 AWS_REGION=ap-northeast-2
 AWS_S3_BUCKET=am-i-hogu-images-847041280547-ap-northeast-2-an
+AWS_CLOUDFRONT_DOMAIN=https://dxxxxxxxxxxxxx.cloudfront.net
 AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_SECRET_ACCESS_KEY=aws_secret_access_key

--- a/env.example
+++ b/env.example
@@ -9,3 +9,8 @@ KAKAO_CLIENT_ID=kakao_client_id
 KAKAO_CLIENT_SECRET=kakao_client_secret
 
 TOKEN_ENCRYPTION_SECRET=base64_encoded_token_encryption_secret
+
+AWS_REGION=ap-northeast-2
+AWS_S3_BUCKET=am-i-hogu-images-847041280547-ap-northeast-2-an
+AWS_ACCESS_KEY_ID=aws_access_key_id
+AWS_SECRET_ACCESS_KEY=aws_secret_access_key

--- a/src/main/java/com/hogu/am_i_hogu/common/config/AwsS3Config.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/config/AwsS3Config.java
@@ -1,0 +1,32 @@
+package com.hogu.am_i_hogu.common.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
@@ -16,13 +16,16 @@ public class S3StorageService {
 
     private final AmazonS3 amazonS3;
     private final String bucket;
+    private final String cloudFrontDomain;
 
     public S3StorageService(
             AmazonS3 amazonS3,
-            @Value("${cloud.aws.s3.bucket}") String bucket
+            @Value("${cloud.aws.s3.bucket}") String bucket,
+            @Value("${cloud.aws.cloudfront.domain}") String cloudFrontDomain
     ) {
         this.amazonS3 = amazonS3;
         this.bucket = bucket;
+        this.cloudFrontDomain = removeTrailingSlash(cloudFrontDomain);
     }
 
     public String upload(String key, MultipartFile file) {
@@ -32,9 +35,16 @@ public class S3StorageService {
 
         try (InputStream inputStream = file.getInputStream()) {
             amazonS3.putObject(bucket, key, inputStream, metadata);
-            return amazonS3.getUrl(bucket, key).toString();
+            return "%s/%s".formatted(cloudFrontDomain, key);
         } catch (IOException e) {
             throw new CustomException(CommonErrorCode.SERVER_ERROR);
         }
+    }
+
+    private String removeTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
@@ -1,0 +1,40 @@
+package com.hogu.am_i_hogu.common.storage;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
+import com.hogu.am_i_hogu.common.exception.CustomException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+public class S3StorageService {
+
+    private final AmazonS3 amazonS3;
+    private final String bucket;
+
+    public S3StorageService(
+            AmazonS3 amazonS3,
+            @Value("${cloud.aws.s3.bucket}") String bucket
+    ) {
+        this.amazonS3 = amazonS3;
+        this.bucket = bucket;
+    }
+
+    public String upload(String key, MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(bucket, key, inputStream, metadata);
+            return amazonS3.getUrl(bucket, key).toString();
+        } catch (IOException e) {
+            throw new CustomException(CommonErrorCode.SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,11 +22,7 @@ public class ImageController {
     public ResponseEntity<ImageUploadResponse> uploadImage(
             @RequestPart(value = "image", required = false) MultipartFile image
     ) {
-        String baseUrl = ServletUriComponentsBuilder
-                .fromCurrentContextPath() // 개발시에는 http://localhost:8080
-                .build()
-                .toUriString();
-        String imageUrl = imageUploadService.upload(image, baseUrl);
+        String imageUrl = imageUploadService.upload(image);
 
         return ResponseEntity.ok(new ImageUploadResponse(imageUrl));
     }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
@@ -1,6 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.exception.ImageErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -24,15 +25,16 @@ public class ImageUploadService {
     );
 
     private final TsidGenerator tsidGenerator;
+    private final S3StorageService s3StorageService;
 
-    public String upload(MultipartFile image, String baseUrl) {
+    public String upload(MultipartFile image) {
         validate(image);
 
         long imageId = tsidGenerator.nextId();
-        String filename = sanitizeFilename(image.getOriginalFilename());
+        String extension = extractExtension(image.getOriginalFilename());
+        String key = "images/posts/%d.%s".formatted(imageId, extension);
 
-        // s3 연동 전 임시 구현 - 실제 파일 저장 없이 API 검증용 이미지 임시 URL만 발급한다.
-        return "%s/temporary/images/%d/%s".formatted(baseUrl, imageId, filename);
+        return s3StorageService.upload(key, image);
     }
 
     private void validate(MultipartFile image) {
@@ -64,12 +66,4 @@ public class ImageUploadService {
         return filename.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
     }
 
-    private String sanitizeFilename(String filename) {
-        if (filename == null || filename.isBlank()) {
-            return "image";
-        }
-
-        // 임시로 파일명이 깨지지 않도록 영어 대/소문자, 숫자, '.', '_', '-'를 제외한 문자를 모두 '_'로 치환한다.
-        return filename.replaceAll("[^A-Za-z0-9._-]", "_");
-    }
 }

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -29,6 +29,20 @@ app:
   cookie:
     secure: true
 
+# aws s3 bucket
+cloud:
+  aws:
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+
 oauth:
   # google 소셜 로그인 정보
   google:

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -34,6 +34,8 @@ cloud:
   aws:
     s3:
       bucket: ${AWS_S3_BUCKET}
+    cloudfront:
+      domain: ${AWS_CLOUDFRONT_DOMAIN}
     credentials:
       access-key: ${AWS_ACCESS_KEY_ID}
       secret-key: ${AWS_SECRET_ACCESS_KEY}

--- a/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
@@ -1,0 +1,46 @@
+package com.hogu.am_i_hogu.common.storage;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class S3StorageServiceTest {
+
+    @Test
+    void uploadStoresFileAndReturnsS3Url() throws Exception {
+        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        S3StorageService s3StorageService = new S3StorageService(
+                amazonS3,
+                "am-i-hogu-images"
+        );
+        MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "post-image.jpg",
+                "image/jpeg",
+                "image-content".getBytes()
+        );
+        when(amazonS3.getUrl("am-i-hogu-images", "images/posts/1.jpg"))
+                .thenReturn(new URL("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg"));
+
+        String imageUrl = s3StorageService.upload("images/posts/1.jpg", image);
+
+        assertThat(imageUrl).isEqualTo("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg");
+        verify(amazonS3).putObject(
+                eq("am-i-hogu-images"),
+                eq("images/posts/1.jpg"),
+                any(InputStream.class),
+                any(ObjectMetadata.class)
+        );
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
@@ -6,23 +6,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.InputStream;
-import java.net.URL;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class S3StorageServiceTest {
 
     @Test
-    void uploadStoresFileAndReturnsS3Url() throws Exception {
+    void uploadStoresFileAndReturnsCloudFrontUrl() {
         AmazonS3 amazonS3 = mock(AmazonS3.class);
         S3StorageService s3StorageService = new S3StorageService(
                 amazonS3,
-                "am-i-hogu-images"
+                "am-i-hogu-images",
+                "https://d111111abcdef8.cloudfront.net"
         );
         MockMultipartFile image = new MockMultipartFile(
                 "image",
@@ -30,12 +29,10 @@ class S3StorageServiceTest {
                 "image/jpeg",
                 "image-content".getBytes()
         );
-        when(amazonS3.getUrl("am-i-hogu-images", "images/posts/1.jpg"))
-                .thenReturn(new URL("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg"));
 
         String imageUrl = s3StorageService.upload("images/posts/1.jpg", image);
 
-        assertThat(imageUrl).isEqualTo("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg");
+        assertThat(imageUrl).isEqualTo("https://d111111abcdef8.cloudfront.net/images/posts/1.jpg");
         verify(amazonS3).putObject(
                 eq("am-i-hogu-images"),
                 eq("images/posts/1.jpg"),

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
@@ -5,6 +5,7 @@ import com.hogu.am_i_hogu.common.security.JwtAuthenticationFilter;
 import com.hogu.am_i_hogu.common.security.JwtAccessDeniedHandler;
 import com.hogu.am_i_hogu.common.security.JwtProvider;
 import com.hogu.am_i_hogu.common.security.SecurityConfig;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.service.ImageUploadService;
 import com.hogu.am_i_hogu.domain.user.domain.User;
@@ -24,6 +25,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -50,9 +52,12 @@ class ImageControllerTest {
     @MockitoBean
     private UserRepository userRepository;
 
-    // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 임시 imageUrl을 반환한다.
+    @MockitoBean
+    private S3StorageService s3StorageService;
+
+    // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 S3 imageUrl을 반환한다.
     @Test
-    void uploadImageReturnsTemporaryImageUrl() throws Exception {
+    void uploadImageReturnsS3ImageUrl() throws Exception {
         when(jwtProvider.validateAccessToken("valid-token"))
                 .thenReturn(JwtProvider.TokenValidationResult.VALID);
         when(jwtProvider.getSubjectAsLong("valid-token"))
@@ -62,9 +67,11 @@ class ImageControllerTest {
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
-                        null,
-                        Collections.emptyList()
-                ));
+                null,
+                Collections.emptyList()
+        ));
+        when(s3StorageService.upload(org.mockito.ArgumentMatchers.startsWith("images/posts/"), any()))
+                .thenReturn("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg");
 
         MockMultipartFile image = new MockMultipartFile(
                 "image",
@@ -77,7 +84,7 @@ class ImageControllerTest {
                         .file(image)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.imageUrl", startsWith("http://localhost/temporary/images/")));
+                .andExpect(jsonPath("$.imageUrl", startsWith("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/")));
     }
 
     // 실패 케이스: multipart 요청에 image 파일이 없으면 400 Bad Request와 EMPTY_IMAGE_FILE을 반환한다.

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
@@ -55,7 +55,7 @@ class ImageControllerTest {
     @MockitoBean
     private S3StorageService s3StorageService;
 
-    // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 S3 imageUrl을 반환한다.
+    // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 CloudFront imageUrl을 반환한다.
     @Test
     void uploadImageReturnsS3ImageUrl() throws Exception {
         when(jwtProvider.validateAccessToken("valid-token"))
@@ -71,7 +71,7 @@ class ImageControllerTest {
                 Collections.emptyList()
         ));
         when(s3StorageService.upload(org.mockito.ArgumentMatchers.startsWith("images/posts/"), any()))
-                .thenReturn("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/1.jpg");
+                .thenReturn("https://d111111abcdef8.cloudfront.net/images/posts/1.jpg");
 
         MockMultipartFile image = new MockMultipartFile(
                 "image",
@@ -84,7 +84,7 @@ class ImageControllerTest {
                         .file(image)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.imageUrl", startsWith("https://am-i-hogu-images.s3.ap-northeast-2.amazonaws.com/images/posts/")));
+                .andExpect(jsonPath("$.imageUrl", startsWith("https://d111111abcdef8.cloudfront.net/images/posts/")));
     }
 
     // 실패 케이스: multipart 요청에 image 파일이 없으면 400 Bad Request와 EMPTY_IMAGE_FILE을 반환한다.

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,6 +36,8 @@ cloud:
   aws:
     s3:
       bucket: test-bucket
+    cloudfront:
+      domain: https://test-cloudfront.example.com
     credentials:
       access-key: test-access-key
       secret-key: test-secret-key

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,19 @@ app:
     login-success-uri: http://localhost:8080/oauth/callback?status=LOGIN_SUCCESS
     login-failure-uri: http://localhost:3000/oauth/callback?status=LOGIN_FAILED
 
+cloud:
+  aws:
+    s3:
+      bucket: test-bucket
+    credentials:
+      access-key: test-access-key
+      secret-key: test-secret-key
+    region:
+      static: ap-northeast-2
+      auto: false
+    stack:
+      auto: false
+
 oauth:
   google:
     client-id: test-client-id


### PR DESCRIPTION
## 📋 변경 사항

- AWS S3 이미지 업로드 설정을 추가했습니다.
  - `spring-cloud-starter-aws` 의존성 추가
  - S3 bucket, region, access key, secret key 설정 추가
  - 테스트 환경용 S3 설정 추가
- `AmazonS3` 클라이언트 설정 클래스를 추가했습니다.
- 이미지 업로드 시 기존 임시 URL 발급 방식에서 실제 S3 업로드 방식으로 변경했습니다.
  - 저장 key 형식: `images/posts/{TSID}.{확장자}`
  - 지원 확장자: `jpg`, `jpeg`, `png`, `webp`
- S3 업로드 서비스 테스트를 추가했습니다.
- 이미지 업로드 컨트롤러 테스트를 S3 URL 반환 기준으로 수정했습니다.

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [x] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 🔗 관련 이슈
- Closes #44 