### PR TITLE
feat: swagger 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.security:spring-security-oauth2-jose'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 
 	// Flyway
 	implementation 'org.flywaydb:flyway-core'

--- a/src/main/java/com/hogu/am_i_hogu/common/config/OpenApiConfig.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/config/OpenApiConfig.java
@@ -1,0 +1,44 @@
+package com.hogu.am_i_hogu.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(OpenApiConfig.OpenApiProperties.class)
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI openAPI(OpenApiProperties properties) {
+        Info info = new Info()
+                .title(properties.title())
+                .version(properties.version());
+
+        Server server = new Server().url(properties.serverUri());
+
+        return new OpenAPI()
+                .info(info)
+                .addServersItem(server)
+                .components(new Components().addSecuritySchemes(
+                        "bearerAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ));
+    }
+
+    @ConfigurationProperties(prefix = "app.openapi")
+    public record OpenApiProperties(
+            String title,
+            String version,
+            String serverUri
+    ) {
+    }
+}

--- a/src/main/java/com/hogu/am_i_hogu/common/config/OpenApiConfig.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/config/OpenApiConfig.java
@@ -3,12 +3,17 @@ package com.hogu.am_i_hogu.common.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Set;
 
 @Configuration
 @EnableConfigurationProperties(OpenApiConfig.OpenApiProperties.class)
@@ -32,6 +37,26 @@ public class OpenApiConfig {
                                 .scheme("bearer")
                                 .bearerFormat("JWT")
                 ));
+    }
+
+    @Bean
+    public OperationCustomizer optionalBearerAuthCustomizer() {
+        Set<String> optionalBearerOperationIds = Set.of(
+                "getHomePosts",
+                "getPostDetail",
+                "getComments"
+        );
+
+        return (operation,handlerMethod) -> {
+            if (optionalBearerOperationIds.contains(operation.getOperationId())) {
+                operation.setSecurity(List.of(
+                        new SecurityRequirement(),
+                        new SecurityRequirement().addList("bearerAuth")
+                ));
+            }
+
+            return operation;
+        };
     }
 
     @ConfigurationProperties(prefix = "app.openapi")

--- a/src/main/java/com/hogu/am_i_hogu/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/exception/ErrorResponse.java
@@ -1,14 +1,20 @@
 package com.hogu.am_i_hogu.common.exception;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@Schema(description = "공통 에러 응답")
 public class ErrorResponse {
+
+    @Schema(description = "에러 코드", example = "INVALID_PARAM_VALUE")
     private String code;
+
+    @Schema(description = "상세 에러(없을 경우 생략)", nullable = true)
     private List<ErrorDetail> errors;
 
     // 상세 오류 리스트가 없는 에러 응답을 위한 생성자
@@ -35,8 +41,12 @@ public class ErrorResponse {
 
     // 상세 오류 리스트 클래스
     @Getter
+    @Schema(description = "필드별 에러 상세")
     public static class ErrorDetail {
+        @Schema(description = "에러 발생한 필드명", example = "nickname")
         private String field;
+
+        @Schema(description = "해당 필드의 상세 에러 코드", example = "SPECIAL_CHAR_NICKNAME")
         private String code;
 
         public ErrorDetail(String field, String code) {

--- a/src/main/java/com/hogu/am_i_hogu/common/health/HealthCheckController.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/health/HealthCheckController.java
@@ -1,9 +1,11 @@
 package com.hogu.am_i_hogu.common.health;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 public class HealthCheckController {
 

--- a/src/main/java/com/hogu/am_i_hogu/common/security/SecurityConfig.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/security/SecurityConfig.java
@@ -39,6 +39,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // Authentication 유무 상관 없는 경우
                         .requestMatchers(HttpMethod.GET, "/api/health").permitAll()
+                        .requestMatchers(                                                   // swagger 관련
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html").permitAll()
                         .requestMatchers(HttpMethod.GET,
                                         "/api/users/check-nickname",                        // USER-002: 닉네임 중복 체크
                                         "/api/posts",                                       // HOME-001: 홈 화면 조회

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthApiDoc.java
@@ -1,0 +1,211 @@
+package com.hogu.am_i_hogu.domain.auth.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.auth.dto.request.OnboardingRequest;
+import com.hogu.am_i_hogu.domain.auth.dto.response.OnboardingResponse;
+import com.hogu.am_i_hogu.domain.auth.dto.response.ReissueResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Auth", description = "서비스 자체 인증(JWT) API")
+public interface AuthApiDoc {
+
+    @Operation(
+            operationId = "createUser",
+            summary = "온보딩",
+            description = "registerToken 쿠키를 사용해 회원 가입을 완료하고 access token을 반환한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    headers = @Header(
+                            name = HttpHeaders.SET_COOKIE,
+                            description = "refreshToken 쿠키와 registerToken 삭제 쿠키가 함께 내려간다."
+                    ),
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = OnboardingResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                            {
+                                              "accessToken": "..."
+                                            }
+                                            """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "닉네임 유효성 검사 실패",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "EMPTY_NICKNAME",
+                                            value = """
+                                                    {
+                                                      "code": "INVALID_INPUT_VALUE",
+                                                      "errors": [
+                                                        {
+                                                          "field": "nickname",
+                                                          "code": "EMPTY_NICKNAME"
+                                                        }
+                                                      ]
+                                                    }
+                                                    """
+                                    ),
+                                    @ExampleObject(
+                                            name = "MULTIPLE_ERRORS",
+                                            value = """
+                                                    {
+                                                      "code": "INVALID_INPUT_VALUE",
+                                                      "errors": [
+                                                        {
+                                                          "field": "nickname",
+                                                          "code": "SPECIAL_CHAR_NICKNAME"
+                                                        },
+                                                        {
+                                                          "field": "nickname",
+                                                          "code": "NICKNAME_LENGTH_EXCEEDED"
+                                                        }
+                                                      ]
+                                                    }
+                                                    """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "임시 토큰이 없거나 만료되었거나 유효하지 않음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "EMPTY_REGISTER_TOKEN", value = "{\"code\":\"EMPTY_REGISTER_TOKEN\"}"),
+                                    @ExampleObject(name = "REGISTER_TOKEN_EXPIRED", value = "{\"code\":\"REGISTER_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "INVALID_REGISTER_TOKEN", value = "{\"code\":\"INVALID_REGISTER_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "닉네임 중복",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"code\":\"DUPLICATE_NICKNAME\"}")
+                    )
+            )
+    })
+    ResponseEntity<OnboardingResponse> createUser(
+            @Parameter(
+                    name = "registerToken",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    description = "회원 가입을 위한 임시 토큰"
+            )
+            String registerToken,
+            OnboardingRequest requestBody
+    );
+
+
+    @Operation(
+            operationId = "refreshAccessToken",
+            summary = "access token 재발급",
+            description = "유효한 refreshToken 쿠키를 검증하여 새로운 access token과 갱신된 refresh token(RTR)을 발급한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공 (새로운 토큰 발급 완료)",
+                    headers = @Header(
+                            name = HttpHeaders.SET_COOKIE,
+                            description = "새롭게 갱신된 refreshToken 쿠키 (HttpOnly, Secure, RTR 적용)"
+                    ),
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ReissueResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "accessToken": "..."
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (Refresh Token 누락, 만료, 변조, 또는 재사용 됨)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "EMPTY_REFRESH_TOKEN", value = "{\"code\":\"EMPTY_REFRESH_TOKEN\"}"),
+                                    @ExampleObject(name = "REFRESH_TOKEN_EXPIRED", value = "{\"code\":\"REFRESH_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "INVALID_REFRESH_TOKEN", value = "{\"code\":\"INVALID_REFRESH_TOKEN\"}"),
+                                    @ExampleObject(name = "REFRESH_TOKEN_REUSED", value = "{\"code\":\"REFRESH_TOKEN_REUSED\"}")
+                            }
+                    )
+            )
+    })
+    ResponseEntity<ReissueResponse> reissueToken(
+            @Parameter(
+                    name = "refreshToken",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    description = "access token 재발급을 위한 refresh token"
+            )
+            String refreshToken
+    );
+
+
+    @Operation(
+            operationId = "logout",
+            summary = "로그아웃",
+            description = "서버 내 Refresh Token을 무효화하고 클라이언트의 쿠키를 삭제하여 로그아웃 처리한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "성공 (로그아웃 완료 및 쿠키 삭제)",
+                    headers = @Header(
+                            name = HttpHeaders.SET_COOKIE,
+                            description = "refreshToken 삭제를 위한 쿠키 (Max-Age=0 옵션 적용)"
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "EMPTY_REFRESH_TOKEN", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<Void> logout(
+            @Parameter(
+                    name = "refreshToken",
+                    in = ParameterIn.COOKIE,
+                    required = true,
+                    description = "로그아웃할 유저의 refresh token"
+            )
+            String refreshToken
+    );
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthApiDoc.java
@@ -47,7 +47,16 @@ public interface AuthApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "닉네임 유효성 검사 실패",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_PARAM_VALUE`
+                            * field: `nickname`
+                            * 하위 오류 코드:
+                                * 필드가 `nickname`:
+                                    * `EMPTY_NICKNAME`: 닉네임이 공백으로만 이루어져 있거나 비어있는 경우
+                                    * `SPECIAL_CHAR_NICKNAME`: 닉네임에 특수문자가 포함되어 있는 경우
+                                    * `NICKNAME_LENGTH_EXCEEDED`: 닉네임 길이가 부족하거나 초과된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -89,7 +98,12 @@ public interface AuthApiDoc {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "임시 토큰이 없거나 만료되었거나 유효하지 않음",
+                    description = """
+                            register token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `REGISTER_TOKEN_EXPIRED`: register token이 만료된 경우
+                            * `EMPTY_REGISTER_TOKEN`: register token이 없는 경우
+                            * `INVALID_REGISTER_TOKEN`: register token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -102,11 +116,28 @@ public interface AuthApiDoc {
             ),
             @ApiResponse(
                     responseCode = "409",
-                    description = "닉네임 중복",
+                    description = """
+                        충돌로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `DUPLICATE_NICKNAME`: 이미 존재하는 닉네임인 경우
+                        """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = "{\"code\":\"DUPLICATE_NICKNAME\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
                     )
             )
     })
@@ -149,7 +180,13 @@ public interface AuthApiDoc {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (Refresh Token 누락, 만료, 변조, 또는 재사용 됨)",
+                    description = """
+                            refresh token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `EMPTY_REFRESH_TOKEN`: refresh token이 없는 경우
+                            * `REFRESH_TOKEN_EXPIRED`: refresh token이 만료된 경우
+                            * `INVALID_REFRESH_TOKEN`: refresh token이 유효하지 않은 경우
+                            * `REFRESH_TOKEN_REUSED`: refresh token이 재사용된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -158,6 +195,20 @@ public interface AuthApiDoc {
                                     @ExampleObject(name = "REFRESH_TOKEN_EXPIRED", value = "{\"code\":\"REFRESH_TOKEN_EXPIRED\"}"),
                                     @ExampleObject(name = "INVALID_REFRESH_TOKEN", value = "{\"code\":\"INVALID_REFRESH_TOKEN\"}"),
                                     @ExampleObject(name = "REFRESH_TOKEN_REUSED", value = "{\"code\":\"REFRESH_TOKEN_REUSED\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
                             }
                     )
             )
@@ -189,12 +240,15 @@ public interface AuthApiDoc {
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "EMPTY_REFRESH_TOKEN", value = "{\"code\":\"SERVER_ERROR\"}"),
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
                             }
                     )
             )

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/controller/AuthController.java
@@ -11,11 +11,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-public class AuthController {
+public class AuthController implements AuthApiDoc {
     private final OnboardingService onboardingService;
     private final ReissueService reissueService;
     private final LogoutService logoutService;

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/request/OnboardingRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/request/OnboardingRequest.java
@@ -1,9 +1,18 @@
 package com.hogu.am_i_hogu.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(name = "OnboardingRequest", description = "온보딩 요청")
 public class OnboardingRequest {
+    @Schema(
+            description = "사용자 닉네임. 한글, 영문, 숫자 2자~20자이며 공백 및 특수문자를 포함할 수 없다.",
+            example = "민돌이",
+            minLength = 2,
+            maxLength = 20,
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
     private final String nickname;
 
     public OnboardingRequest(String nickname) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/OnboardingResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/OnboardingResponse.java
@@ -1,9 +1,15 @@
 package com.hogu.am_i_hogu.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(name = "OnboardingResponse", description = "온보딩 응답")
 public class OnboardingResponse {
+    @Schema(
+            description = "사용자의 access token",
+            example = "eyJhbGciOiJIUzI1NiJ9..."
+    )
     private final String accessToken;
 
     public OnboardingResponse(String accessToken) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/ReissueResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/ReissueResponse.java
@@ -1,9 +1,15 @@
 package com.hogu.am_i_hogu.domain.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(name = "ReissueResponse", description = "토큰 재발급 응답")
 public class ReissueResponse {
+    @Schema(
+            description = "재발급된 access token",
+            example = "eyJhbGciOiJIUzI1NiJ9..."
+    )
     private final String accessToken;
 
     public ReissueResponse(String accessToken) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentApiDoc.java
@@ -1,0 +1,692 @@
+package com.hogu.am_i_hogu.domain.comment.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.common.openapi.OpenApiDescription;
+import com.hogu.am_i_hogu.domain.comment.dto.request.CommentCreateRequest;
+import com.hogu.am_i_hogu.domain.comment.dto.request.CommentUpdateRequest;
+import com.hogu.am_i_hogu.domain.comment.dto.request.CursorRequest;
+import com.hogu.am_i_hogu.domain.comment.dto.response.CommentCreateResponse;
+import com.hogu.am_i_hogu.domain.comment.dto.response.CommentHelpfulResponse;
+import com.hogu.am_i_hogu.domain.comment.dto.response.CommentReadResponse;
+import com.hogu.am_i_hogu.domain.comment.dto.response.CommentUpdateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "Comment", description = "집단지성 API")
+public interface CommentApiDoc {
+
+    @Operation(
+            operationId = "getComments",
+            summary = "집단지성 목록 조회",
+            description = "게시물의 집단지성 목록을 무한 스크롤 방식으로 조회한다. Authorization 헤더(Access Token)를 포함하여 요청하면 '내 집단지성 여부(isMine)' 및 '유익해요 누름 여부(isHelpful)'가 유저에 맞게 판별되어 반환된다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommentReadResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "comments": [
+                                            {
+                                              "commentId": 1234,
+                                              "content": "호구같아요.",
+                                              "isMine": false,
+                                              "writer": {
+                                                "nickname": "민돌이",
+                                                "profileImageUrl": "https://...",
+                                                "isPostWriter": false
+                                              },
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "updatedAt": "2026-03-31T11:49:05",
+                                              "isDeleted": false,
+                                              "isHelpful": false,
+                                              "totalHelpfulCount": 32,
+                                              "parentId": 12,
+                                              "depth": 1
+                                            }
+                                          ],
+                                          "hasNext": false,
+                                          "nextCursor": "SDLEI1J3787"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (postId 타입 오류 또는 조회 파라미터 오류)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "WRONG_POSTID_TYPE",
+                                            summary = "postId 타입 오류",
+                                            value = "{\"code\":\"WRONG_POSTID_TYPE\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "INVALID_PARAM_VALUE",
+                                            summary = "파라미터 오류 (정렬/커서)",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_PARAM_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "cursor",
+                                                      "code": "INVALID_CURSOR"
+                                                    },
+                                                    {
+                                                      "field": "sortBy",
+                                                      "code": "MULTIPLE_SORTING"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물을 찾을 수 없음 (삭제되었거나 존재하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CommentReadResponse> read(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @ParameterObject
+            CursorRequest cursorRequest
+    );
+
+    @Operation(
+            operationId = "createComment",
+            summary = "집단지성 생성",
+            description = "특정 게시물에 새로운 집단지성을 작성한다. Authorization 헤더(Access Token)가 필수로 요구된다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommentCreateResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "commentId": 1234,
+                                          "content": "호구같아요.",
+                                          "isMine": false,
+                                          "writer": {
+                                            "nickname": "민돌이",
+                                            "profileImageUrl": "https://...",
+                                            "isPostWriter": false
+                                          },
+                                          "createdAt": "2026-03-31T11:49:05",
+                                          "updatedAt": "2026-03-31T11:49:05",
+                                          "isHelpful": false,
+                                          "totalHelpfulCount": 32,
+                                          "parentId": 12,
+                                          "depth": 1
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (타입 오류, 바디 누락, 입력값 정책 위반)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", summary = "postId 타입 오류", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", summary = "요청 바디 비어있음", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
+                                    @ExampleObject(name = "WRONG_PARENTID_TYPE", summary = "parentId 타입 오류", value = "{\"code\":\"WRONG_PARENTID_TYPE\"}"),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE",
+                                            summary = "입력값 정책 위반 (공백, 길이/뎁스 초과)",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "content",
+                                                      "code": "EMPTY_CONTENT"
+                                                    },
+                                                    {
+                                                      "field": "depth",
+                                                      "code": "DEPTH_EXCEEDED"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물, 부모 집단지성, 또는 사용자를 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "PARENT_ALREADY_DELETED", summary = "삭제된 부모 집단지성", value = "{\"code\":\"PARENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "PARENT_NOT_FOUND", summary = "존재하지 않는 부모 집단지성", value = "{\"code\":\"PARENT_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "USER_NOT_FOUND", summary = "존재하지 않는 사용자", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CommentCreateResponse> create(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "집단지성을 작성하려는 게시물의 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @RequestBody(
+                    description = "집단지성 생성 데이터 (대댓글이 아닐 경우 parentId는 null)"
+            )
+            CommentCreateRequest request
+    );
+
+    @Operation(
+            operationId = "updateComment",
+            summary = "집단지성 수정",
+            description = "특정 게시물에 작성된 자신의 집단지성을 수정한다. 해당 집단지의 작성자(소유자)만 수정할 수 있으며, Authorization 헤더(Access Token)가 필수로 요구된다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommentUpdateResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "commentId": 1234,
+                                          "content": "호구같아요.",
+                                          "isMine": false,
+                                          "writer": {
+                                            "nickname": "민돌이",
+                                            "profileImageUrl": "https://...",
+                                            "isPostWriter": false
+                                          },
+                                          "createdAt": "2026-03-31T11:49:05",
+                                          "updatedAt": "2026-03-31T11:49:05",
+                                          "isHelpful": false,
+                                          "totalHelpfulCount": 32,
+                                          "parentId": 12,
+                                          "depth": 1
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (타입 오류, 바디 누락, 본문 길이 및 공백 정책 위반)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", summary = "postId 타입 오류", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", summary = "commentId 타입 오류", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}"),
+                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", summary = "요청 바디 비어있음", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
+                                    @ExampleObject(name = "EMPTY_CONTENT", summary = "본문이 비어있거나 공백", value = "{\"code\":\"EMPTY_CONTENT\"}"),
+                                    @ExampleObject(name = "CONTENT_LENGTH_EXCEEDED", summary = "본문 길이 초과", value = "{\"code\":\"CONTENT_LENGTH_EXCEEDED\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (요청한 유저가 해당 집단지성의 작성자가 아님)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", summary = "작성자 불일치", value = "{\"code\":\"FORBIDDEN_ACCESS\"}"
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", summary = "삭제된 집단지성", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", summary = "존재하지 않는 집단지성", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CommentUpdateResponse> update(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @Parameter(
+                    name = "commentId",
+                    description = "수정할 집단지성 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long commentId,
+
+            @RequestBody(
+                    description = "수정할 집단지성 본문 데이터"
+            )
+            CommentUpdateRequest request
+    );
+
+    @Operation(
+            operationId = "deleteComment",
+            summary = "집단지성 삭제",
+            description = "특정 게시물에 작성된 자신의 집단지성을 삭제합니다. 해당 집단지성의 작성자(소유자)만 삭제할 수 있으며, Authorization 헤더(Access Token)가 필수로 요구됩니다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "삭제 성공 (응답 본문 없음)"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", summary = "postId 타입 오류", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", summary = "commentId 타입 오류", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (요청한 유저가 해당 집단지의 작성자가 아님)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "FORBIDDEN_ACCESS",
+                                    summary = "작성자 불일치",
+                                    value = "{\"code\":\"FORBIDDEN_ACCESS\"}"
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", summary = "삭제된 집단지성", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", summary = "존재하지 않는 집단지성", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<Void> delete(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @Parameter(
+                    name = "commentId",
+                    description = "삭제할 집단지성 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long commentId
+    );
+
+    @Operation(
+            operationId = "createCommentHelpful",
+            summary = "집단지성 유익해요 등록",
+            description = "특정 집단지성에 '유익해요'를 등록한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommentHelpfulResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "totalHelpfulCount": 123,
+                                          "isHelpful": true
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (본인 집단지성에는 유익해요 불가)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물 또는 집단지을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "중복 요청 (이미 유익해요가 선택된 상태)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "DUPLICATE_REQUEST", value = "{\"code\":\"DUPLICATE_REQUEST\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CommentHelpfulResponse> createHelpful(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @Parameter(
+                    name = "commentId",
+                    description = "집단지성 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long commentId
+    );
+
+    @Operation(
+            operationId = "deleteCommentHelpful",
+            summary = "집단지성 유익해요 취소",
+            description = "특정 집단지성에 등록한 '유익해요'를 취소한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CommentHelpfulResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "totalHelpfulCount": 123,
+                                          "isHelpful": false
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CommentHelpfulResponse> deleteHelpful(
+            Authentication authentication,
+
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            @Parameter(
+                    name = "commentId",
+                    description = "집단지성 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long commentId
+    );
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentApiDoc.java
@@ -1,7 +1,6 @@
 package com.hogu.am_i_hogu.domain.comment.controller;
 
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.openapi.OpenApiDescription;
 import com.hogu.am_i_hogu.domain.comment.dto.request.CommentCreateRequest;
 import com.hogu.am_i_hogu.domain.comment.dto.request.CommentUpdateRequest;
 import com.hogu.am_i_hogu.domain.comment.dto.request.CursorRequest;
@@ -70,7 +69,18 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (postId 타입 오류 또는 조회 파라미터 오류)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_PARAM_VALUE`, `WRONG_POSTID_TYPE`
+                            (상세 오류 정보는 상위 오류 코드가 `INVALID_PARAM_VALUE`인 경우에만 포함)
+                            * field: `sortBy`, `cursor`
+                            * 하위 오류 코드:
+                                * 필드가 `sortBy`:
+                                    * `INVALID_SORTING`: 존재하지 않는 정렬 기준인 경우
+                                    * `MULTIPLE_SORTING`: 정렬 기준이 다중 선택된 경우
+                                * 필드가 `cursor`:
+                                    * `INVALID_CURSOR`: 유효하지 않은 cursor인 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -104,19 +114,26 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물을 찾을 수 없음 (삭제되었거나 존재하지 않음)",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
-                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}")
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -178,7 +195,18 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (타입 오류, 바디 누락, 입력값 정책 위반)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_INPUT_VALUE`, `WRONG_POSTID_TYPE`, `EMPTY_REQUEST_BODY`, `WRONG_PARENTID_TYPE`
+                            (상세 오류 정보는 상위 오류 코드가 `INVALID_INPUT_VALUE`인 경우에만 포함)
+                            * field: `content`, `depth`
+                            * 하위 오류 코드:
+                                * 필드가 `content`:
+                                    * `EMPTY_CONTENT`: 내용이 공백으로만 이루어져 있거나 비어있는 경우
+                                    * `CONTENT_LENGTH_EXCEEDED`: 내용 길이를 초과한 경우
+                                * 필드가 `depth`:
+                                    * `DEPTH_EXCEEDED`: depth 1인 집단지성에 대댓글을 다는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -210,35 +238,50 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
-                                @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
-                                @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물, 부모 집단지성, 또는 사용자를 찾을 수 없음",
+                    description = """
+                            게시물, 부모 집단지성, 또는 사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            * `PARENT_ALREADY_DELETED`: 이미 삭제된 부모 집단지성인 경우
+                            * `PARENT_NOT_FOUND`: 부모 집단지성을 찾을 수 없는 경우
+                            * `USER_NOT_FOUND`: 사용자를 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
-                                    @ExampleObject(name = "PARENT_ALREADY_DELETED", summary = "삭제된 부모 집단지성", value = "{\"code\":\"PARENT_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "PARENT_NOT_FOUND", summary = "존재하지 않는 부모 집단지성", value = "{\"code\":\"PARENT_NOT_FOUND\"}"),
-                                    @ExampleObject(name = "USER_NOT_FOUND", summary = "존재하지 않는 사용자", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "PARENT_ALREADY_DELETED", value = "{\"code\":\"PARENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "PARENT_NOT_FOUND", value = "{\"code\":\"PARENT_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -302,22 +345,34 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (타입 오류, 바디 누락, 본문 길이 및 공백 정책 위반)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            * `WRONG_COMMENTID_TYPE`: commentId 타입이 잘못된 경우
+                            * `EMPTY_REQUEST_BODY`: 요청 바디가 비어있는 경우
+                            * `EMPTY_CONTENT`: 집단지성의 `content` 필드가 없거나 비어있는 경우
+                            * `CONTENT_LENGTH_EXCEEDED`: 집단지성의 `content` 필드 길이가 초과된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "WRONG_POSTID_TYPE", summary = "postId 타입 오류", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
-                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", summary = "commentId 타입 오류", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}"),
-                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", summary = "요청 바디 비어있음", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
-                                    @ExampleObject(name = "EMPTY_CONTENT", summary = "본문이 비어있거나 공백", value = "{\"code\":\"EMPTY_CONTENT\"}"),
-                                    @ExampleObject(name = "CONTENT_LENGTH_EXCEEDED", summary = "본문 길이 초과", value = "{\"code\":\"CONTENT_LENGTH_EXCEEDED\"}")
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}"),
+                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
+                                    @ExampleObject(name = "EMPTY_CONTENT", value = "{\"code\":\"EMPTY_CONTENT\"}"),
+                                    @ExampleObject(name = "CONTENT_LENGTH_EXCEEDED", value = "{\"code\":\"CONTENT_LENGTH_EXCEEDED\"}")
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -330,31 +385,42 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "권한 없음 (요청한 유저가 해당 집단지성의 작성자가 아님)",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 해당 집단지성의 소유자가 아닌 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", summary = "작성자 불일치", value = "{\"code\":\"FORBIDDEN_ACCESS\"}"
-                            )
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
                     )
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    description = """
+                            게시물, 집단지성을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            * `COMMENT_ALREADY_DELETED`: 이미 삭제된 집단지성인 경우
+                            * `COMMENT_NOT_FOUND`: 집단지성을 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
-                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", summary = "삭제된 집단지성", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "COMMENT_NOT_FOUND", summary = "존재하지 않는 집단지성", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENt_NOT_FOUND\"}"),
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -392,7 +458,7 @@ public interface CommentApiDoc {
     @Operation(
             operationId = "deleteComment",
             summary = "집단지성 삭제",
-            description = "특정 게시물에 작성된 자신의 집단지성을 삭제합니다. 해당 집단지성의 작성자(소유자)만 삭제할 수 있으며, Authorization 헤더(Access Token)가 필수로 요구됩니다.",
+            description = "특정 게시물에 작성된 자신의 집단지성을 삭제한다. 해당 집단지성의 작성자(소유자)만 삭제할 수 있으며, Authorization 헤더(Access Token)가 필수로 요구된다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses(value = {
@@ -402,19 +468,28 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            * `WRONG_COMMENTID_TYPE`: commentId 타입이 잘못된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "WRONG_POSTID_TYPE", summary = "postId 타입 오류", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
-                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", summary = "commentId 타입 오류", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}")
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "WRONG_COMMENTID_TYPE", value = "{\"code\":\"WRONG_COMMENTID_TYPE\"}")
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -427,34 +502,42 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "권한 없음 (요청한 유저가 해당 집단지의 작성자가 아님)",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 해당 집단지성의 작성자가 아닌 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
-                            examples = @ExampleObject(
-                                    name = "FORBIDDEN_ACCESS",
-                                    summary = "작성자 불일치",
-                                    value = "{\"code\":\"FORBIDDEN_ACCESS\"}"
-                            )
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
                     )
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    description = """
+                            게시물, 집단지성을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            * `COMMENT_ALREADY_DELETED`: 이미 삭제된 집단지성인 경우
+                            * `COMMENT_NOT_FOUND`: 집단지성을 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
                             examples = {
-                                    @ExampleObject(name = "POST_ALREADY_DELETED", summary = "삭제된 게시물", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "POST_NOT_FOUND", summary = "존재하지 않는 게시물", value = "{\"code\":\"POST_NOT_FOUND\"}"),
-                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", summary = "삭제된 집단지성", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "COMMENT_NOT_FOUND", summary = "존재하지 않는 집단지성", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENt_NOT_FOUND\"}"),
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -509,7 +592,11 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            * `WRONG_COMMENTID_TYPE`: commentId 타입이 잘못된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -521,7 +608,12 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -534,7 +626,10 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "403",
-                    description = "권한 없음 (본인 집단지성에는 유익해요 불가)",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 집단지성 작성자인 경우(본인 집단지성에는 유익해요 불가)
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -543,7 +638,13 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물 또는 집단지을 찾을 수 없음",
+                    description = """
+                            게시물, 집단지성을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            * `COMMENT_ALREADY_DELETED`: 이미 삭제된 집단지성인 경우
+                            * `COMMENT_NOT_FOUND`: 집단지성을 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -551,13 +652,16 @@ public interface CommentApiDoc {
                                     @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
                                     @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
                                     @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENt_NOT_FOUND\"}"),
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "409",
-                    description = "중복 요청 (이미 유익해요가 선택된 상태)",
+                    description = """
+                        충돌로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `DUPLICATE_REQUEST`: 이미 유익해요가 등록되어 있는 경우
+                        """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -566,7 +670,10 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -621,7 +728,11 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "400",
-                    description = "잘못된 요청 (postId 또는 commentId 타입 오류)",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            * `WRONG_COMMENTID_TYPE`: commentId 타입이 잘못된 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -633,7 +744,12 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (토큰 누락 및 유효하지 않음)",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -646,7 +762,13 @@ public interface CommentApiDoc {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "게시물 또는 집단지성을 찾을 수 없음",
+                    description = """
+                            게시물, 집단지성을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            * `COMMENT_ALREADY_DELETED`: 이미 삭제된 집단지성인 경우
+                            * `COMMENT_NOT_FOUND`: 집단지성을 찾을 수 없는 경우
+                            """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),
@@ -654,13 +776,16 @@ public interface CommentApiDoc {
                                     @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
                                     @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
                                     @ExampleObject(name = "COMMENT_ALREADY_DELETED", value = "{\"code\":\"COMMENT_ALREADY_DELETED\"}"),
-                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENT_NOT_FOUND\"}")
+                                    @ExampleObject(name = "COMMENT_NOT_FOUND", value = "{\"code\":\"COMMENt_NOT_FOUND\"}"),
                             }
                     )
             ),
             @ApiResponse(
                     responseCode = "500",
-                    description = "서버 오류",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
                     content = @Content(
                             mediaType = "application/json",
                             schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.hogu.am_i_hogu.domain.comment.dto.response.CommentCreateResponse;
 import com.hogu.am_i_hogu.domain.comment.dto.response.CommentHelpfulResponse;
 import com.hogu.am_i_hogu.domain.comment.dto.response.CommentReadResponse;
 import com.hogu.am_i_hogu.domain.comment.dto.response.CommentUpdateResponse;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.HttpStatus;
 import com.hogu.am_i_hogu.domain.comment.service.*;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/posts")
-public class CommentController {
+public class CommentController implements CommentApiDoc {
 
     private final CommentCreateService commentCreateService;
     private final CommentReadService commentReadService;
@@ -49,7 +50,7 @@ public class CommentController {
     public ResponseEntity<CommentReadResponse> read(
             Authentication authentication,
             @PathVariable Long postId,
-            @ModelAttribute CursorRequest cursorRequest
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
     ) {
         Long userId = authentication == null ? null : Long.valueOf(authentication.getName());
         CommentReadResponse response = commentReadService.read(userId, postId, cursorRequest);

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,7 +1,12 @@
 package com.hogu.am_i_hogu.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommentCreateRequest", description = "댓글 생성 요청")
 public record CommentCreateRequest(
+        @Schema(description = "부모 댓글 ID", nullable = true)
         Long parentId,
+        @Schema(description = "댓글 내용")
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
@@ -2,11 +2,17 @@ package com.hogu.am_i_hogu.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentCreateRequest", description = "댓글 생성 요청")
+@Schema(
+        name = "CommentCreateRequest",
+        description = "집단지성 생성 요청. 최상위 집단지성은 parentId를 비워두고, 대댓글은 parentId에 부모 집단지성 ID를 넣는다."
+)
 public record CommentCreateRequest(
-        @Schema(description = "부모 댓글 ID", nullable = true)
+        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true, example = "12")
         Long parentId,
-        @Schema(description = "댓글 내용")
+        @Schema(
+                description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.",
+                example = "호구같아요."
+        )
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,6 +1,10 @@
 package com.hogu.am_i_hogu.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommentUpdateRequest", description = "댓글 수정 요청")
 public record CommentUpdateRequest(
+        @Schema(description = "댓글 내용")
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
@@ -2,9 +2,12 @@ package com.hogu.am_i_hogu.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentUpdateRequest", description = "댓글 수정 요청")
+@Schema(name = "CommentUpdateRequest", description = "집단지성 수정 요청")
 public record CommentUpdateRequest(
-        @Schema(description = "댓글 내용")
+        @Schema(
+                description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.",
+                example = "호구같아요."
+        )
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CursorRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CursorRequest.java
@@ -2,18 +2,18 @@ package com.hogu.am_i_hogu.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentCursorRequest", description = "댓글 목록 조회 조건")
+@Schema(name = "CommentCursorRequest", description = "집단지성 목록 조회 조건")
 public record CursorRequest(
         @Schema(
-                description = "정렬 기준",
+                description = "정렬 기준. LATEST는 최신순, HELPFUL은 유익해요 많은 순",
                 allowableValues = {"LATEST", "HELPFUL"},
                 defaultValue = "LATEST",
                 nullable = true
         )
         String sortBy,
-        @Schema(description = "페이지 크기", defaultValue = "5", nullable = true)
+        @Schema(description = "페이지 크기. 최소 1, 최대 15이며 생략 시 기본값은 5", defaultValue = "5", nullable = true)
         Integer pageSize,
-        @Schema(description = "다음 페이지 커서", nullable = true)
+        @Schema(description = "다음 페이지 커서. 이전 응답의 nextCursor 값을 그대로 사용", nullable = true)
         String cursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CursorRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CursorRequest.java
@@ -1,8 +1,19 @@
 package com.hogu.am_i_hogu.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommentCursorRequest", description = "댓글 목록 조회 조건")
 public record CursorRequest(
+        @Schema(
+                description = "정렬 기준",
+                allowableValues = {"LATEST", "HELPFUL"},
+                defaultValue = "LATEST",
+                nullable = true
+        )
         String sortBy,
+        @Schema(description = "페이지 크기", defaultValue = "5", nullable = true)
         Integer pageSize,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String cursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
@@ -1,17 +1,30 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "CommentCreateResponse", description = "댓글 생성 응답")
 public record CommentCreateResponse(
+        @Schema(description = "댓글 ID")
         Long commentId,
+        @Schema(description = "댓글 내용")
         String content,
+        @Schema(description = "내 댓글 여부")
         boolean isMine,
+        @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
+        @Schema(description = "생성 시각")
         LocalDateTime createdAt,
+        @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
+        @Schema(description = "유익해요 선택 여부")
         boolean isHelpful,
+        @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
+        @Schema(description = "부모 댓글 ID", nullable = true)
         Long parentId,
+        @Schema(description = "댓글 깊이")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentCreateResponse", description = "댓글 생성 응답")
+@Schema(name = "CommentCreateResponse", description = "집단지성 생성 응답")
 public record CommentCreateResponse(
-        @Schema(description = "댓글 ID")
+        @Schema(description = "집단지성 ID")
         Long commentId,
-        @Schema(description = "댓글 내용")
+        @Schema(description = "집단지성 내용")
         String content,
-        @Schema(description = "내 댓글 여부")
+        @Schema(description = "내가 작성한 집단지성 여부. 생성 직후에는 항상 true")
         boolean isMine,
         @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
@@ -18,13 +18,13 @@ public record CommentCreateResponse(
         LocalDateTime createdAt,
         @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
-        @Schema(description = "유익해요 선택 여부")
+        @Schema(description = "현재 사용자의 유익해요 선택 여부. 생성 직후에는 항상 false")
         boolean isHelpful,
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
-        @Schema(description = "부모 댓글 ID", nullable = true)
+        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true, example = "12")
         Long parentId,
-        @Schema(description = "댓글 깊이")
+        @Schema(description = "집단지성 깊이. 최상위는 0, 대댓글은 1")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
@@ -2,11 +2,11 @@ package com.hogu.am_i_hogu.domain.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentHelpfulResponse", description = "댓글 유익해요 응답")
+@Schema(name = "CommentHelpfulResponse", description = "집단지성 유익해요 응답")
 public record CommentHelpfulResponse(
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
-        @Schema(description = "유익해요 선택 여부")
+        @Schema(description = "현재 사용자의 유익해요 선택 여부")
         boolean isHelpful
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
@@ -1,7 +1,12 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommentHelpfulResponse", description = "댓글 유익해요 응답")
 public record CommentHelpfulResponse(
+        @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
+        @Schema(description = "유익해요 선택 여부")
         boolean isHelpful
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentItemResponse", description = "댓글 항목")
+@Schema(name = "CommentItemResponse", description = "집단지성 항목")
 public record CommentItemResponse(
-        @Schema(description = "댓글 ID")
+        @Schema(description = "집단지성 ID")
         Long commentId,
-        @Schema(description = "댓글 내용")
+        @Schema(description = "집단지성 내용")
         String content,
-        @Schema(description = "내 댓글 여부")
+        @Schema(description = "내가 작성한 집단지성 여부")
         boolean isMine,
         @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
@@ -20,13 +20,13 @@ public record CommentItemResponse(
         LocalDateTime updatedAt,
         @Schema(description = "삭제 여부")
         boolean isDeleted,
-        @Schema(description = "유익해요 선택 여부")
+        @Schema(description = "현재 사용자의 유익해요 선택 여부")
         boolean isHelpful,
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
-        @Schema(description = "부모 댓글 ID", nullable = true)
+        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true)
         Long parentId,
-        @Schema(description = "댓글 깊이")
+        @Schema(description = "집단지성 깊이. 최상위는 0, 대댓글은 1")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
@@ -1,18 +1,32 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "CommentItemResponse", description = "댓글 항목")
 public record CommentItemResponse(
+        @Schema(description = "댓글 ID")
         Long commentId,
+        @Schema(description = "댓글 내용")
         String content,
+        @Schema(description = "내 댓글 여부")
         boolean isMine,
+        @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
+        @Schema(description = "생성 시각")
         LocalDateTime createdAt,
+        @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
+        @Schema(description = "삭제 여부")
         boolean isDeleted,
+        @Schema(description = "유익해요 선택 여부")
         boolean isHelpful,
+        @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
+        @Schema(description = "부모 댓글 ID", nullable = true)
         Long parentId,
+        @Schema(description = "댓글 깊이")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
@@ -1,10 +1,17 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "CommentReadResponse", description = "댓글 목록 응답")
 public record CommentReadResponse(
+        @ArraySchema(arraySchema = @Schema(description = "댓글 목록"))
         List<CommentItemResponse> comments,
+        @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "CommentReadResponse", description = "댓글 목록 응답")
+@Schema(name = "CommentReadResponse", description = "집단지성 목록 응답")
 public record CommentReadResponse(
-        @ArraySchema(arraySchema = @Schema(description = "댓글 목록"))
+        @ArraySchema(arraySchema = @Schema(description = "집단지성 목록"))
         List<CommentItemResponse> comments,
         @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
-        @Schema(description = "다음 페이지 커서", nullable = true)
+        @Schema(description = "다음 페이지 커서. hasNext가 false이면 null", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
@@ -4,13 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentUpdateResponse", description = "댓글 수정 응답")
+@Schema(name = "CommentUpdateResponse", description = "집단지성 수정 응답")
 public record CommentUpdateResponse(
-        @Schema(description = "댓글 ID")
+        @Schema(description = "집단지성 ID")
         Long commentId,
-        @Schema(description = "댓글 내용")
+        @Schema(description = "집단지성 내용")
         String content,
-        @Schema(description = "내 댓글 여부")
+        @Schema(description = "내가 작성한 집단지성 여부. 수정 성공 시 항상 true")
         boolean isMine,
         @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
@@ -18,13 +18,13 @@ public record CommentUpdateResponse(
         LocalDateTime createdAt,
         @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
-        @Schema(description = "유익해요 선택 여부")
+        @Schema(description = "현재 사용자의 유익해요 선택 여부. 수정 성공 시 항상 false")
         boolean isHelpful,
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
-        @Schema(description = "부모 댓글 ID", nullable = true)
+        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true)
         Long parentId,
-        @Schema(description = "댓글 깊이")
+        @Schema(description = "집단지성 깊이. 최상위는 0, 대댓글은 1")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
@@ -1,17 +1,30 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "CommentUpdateResponse", description = "댓글 수정 응답")
 public record CommentUpdateResponse(
+        @Schema(description = "댓글 ID")
         Long commentId,
+        @Schema(description = "댓글 내용")
         String content,
+        @Schema(description = "내 댓글 여부")
         boolean isMine,
+        @Schema(description = "작성자 정보")
         CommentWriterResponse writer,
+        @Schema(description = "생성 시각")
         LocalDateTime createdAt,
+        @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
+        @Schema(description = "유익해요 선택 여부")
         boolean isHelpful,
+        @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
+        @Schema(description = "부모 댓글 ID", nullable = true)
         Long parentId,
+        @Schema(description = "댓글 깊이")
         int depth
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
@@ -1,8 +1,14 @@
 package com.hogu.am_i_hogu.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CommentWriterResponse", description = "댓글 작성자 정보")
 public record CommentWriterResponse(
+        @Schema(description = "닉네임")
         String nickname,
+        @Schema(description = "프로필 이미지 URL", nullable = true)
         String profileImageUrl,
+        @Schema(description = "게시물 작성자 여부")
         boolean isPostWriter
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
@@ -2,11 +2,11 @@ package com.hogu.am_i_hogu.domain.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentWriterResponse", description = "댓글 작성자 정보")
+@Schema(name = "CommentWriterResponse", description = "집단지성 작성자 정보")
 public record CommentWriterResponse(
-        @Schema(description = "닉네임")
+        @Schema(description = "작성자 닉네임")
         String nickname,
-        @Schema(description = "프로필 이미지 URL", nullable = true)
+        @Schema(description = "작성자 프로필 이미지 URL", nullable = true)
         String profileImageUrl,
         @Schema(description = "게시물 작성자 여부")
         boolean isPostWriter

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthApiDoc.java
@@ -1,0 +1,257 @@
+package com.hogu.am_i_hogu.domain.oauth.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.oauth.domain.OAuthProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "OAuth", description = "OAuth API")
+public interface OAuthApiDoc {
+
+    @Operation(
+            operationId = "login",
+            summary = "OAuth 로그인 시작",
+            description = "OAuth 제공자 로그인 페이지로 리다이렉트한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "성공. OAuth 제공자 로그인 페이지로 리다이렉트한다.",
+                    headers = @Header(
+                            name = "Location",
+                            description = "Authorization server의 로그인 창 URL"
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `UNSUPPORTED_PROVIDER`: 지원하지 않는 provider가 입력된 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "UNSUPPORTED_PROVIDER", value = "{\"code\":\"UNSUPPORTED_PROVIDER\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<Void> redirectToProviderLogin(
+            @Parameter(
+                    name = "provider",
+                    description = "소셜 로그인 제공자 (GOOGLE, KAKAO)",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            String provider
+    );
+
+    @Operation(
+            operationId = "handleOAuthCallback",
+            summary = "OAuth 로그인 콜백 처리",
+            description = "OAuth 인가 코드를 받아 로그인을 처리하고 결과에 따라 프론트엔드로 리다이렉트한다. 실패 시 오류 코드와 함께 리다이렉트 처리된다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "302",
+                    description = "로그인 처리를 완료하고 프론트엔드로 리다이렉트한다.",
+                    headers = {
+                            @Header(
+                                    name = "Location",
+                                    description = "기존 회원 로그인 성공 시, 신규 회원 온보딩 페이지, 또는 실패 시 오류 코드가 포함된 URL"
+                            ),
+                            @Header(
+                                    name = "Set-Cookie",
+                                    description = "기존 회원은 refreshToken, 신규 회원은 registerToken이 포함되며 실패 시에는 포함되지 않는다."
+                            )
+                    }
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `UNSUPPORTED_PROVIDER`: 지원하지 않는 provider가 입력된 경우
+                        * `PROVIDER_MISMATCH`: DB에 저장된 state-provider의 조합과 일치하지 않는 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "UNSUPPORTED_PROVIDER", value = "{\"code\":\"UNSUPPORTED_PROVIDER\"}"),
+                                    @ExampleObject(name = "PROVIDER_MISMATCH", value = "{\"code\":\"PROVIDER_MISMATCH\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                        인가 검증 실패로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `INVALID_STATE`: state 값이 서버에 없거나 일치하지 않는 경우
+                        * `STATE_REUSED`: state 값이 이미 사용된 값인 경우
+                        * `STATE_EXPIRED`: state 값이 만료된 경우
+                        * `INVALID_AUTH_CODE`: code가 유효하지 않거나 만료된 경우
+                        * `INVALID_ID_TOKEN`: 발급받은 id_token이 유효하지 않은 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "INVALID_STATE", value = "{\"code\":\"INVALID_STATE\"}"),
+                                    @ExampleObject(name = "STATE_REUSED", value = "{\"code\":\"STATE_REUSED\"}"),
+                                    @ExampleObject(name = "STATE_EXPIRED", value = "{\"code\":\"STATE_EXPIRED\"}"),
+                                    @ExampleObject(name = "INVALID_AUTH_CODE", value = "{\"code\":\"INVALID_AUTH_CODE\"}"),
+                                    @ExampleObject(name = "INVALID_ID_TOKEN", value = "{\"code\":\"INVALID_ID_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = """
+                        소셜 서버 연동 오류로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `SOCIAL_SERVER_ERROR`: 소셜 서버로부터 정상적인 응답을 받지 못한 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "SOCIAL_SERVER_ERROR", value = "{\"code\":\"SOCIAL_SERVER_ERROR\"}")
+                    )
+            )
+    })
+    ResponseEntity<Void> handleCallback(
+            @Parameter(
+                    name = "provider",
+                    description = "소셜 로그인 제공자 (GOOGLE, KAKAO)",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            String provider,
+
+            @Parameter(
+                    name = "code",
+                    description = "Authorization server로부터 발급 받은 일회용 인가 코드",
+                    in = ParameterIn.QUERY,
+                    required = true
+            )
+            String code,
+
+            @Parameter(
+                    name = "state",
+                    description = "CSRF 공격 방어를 위한 무작위 난수",
+                    in = ParameterIn.QUERY,
+                    required = true
+            )
+            String state
+    );
+
+    @Operation(
+            operationId = "deleteUser",
+            summary = "회원 탈퇴",
+            description = "회원 탈퇴를 처리하고 리프레시 토큰 쿠키를 삭제한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "성공",
+                    headers = @Header(
+                            name = "Set-Cookie",
+                            description = "refreshToken 삭제를 위해 Max-Age=0 옵션을 적용한 쿠키"
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                        사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `USER_NOT_FOUND`: 존재하지 않는 사용자인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "502",
+                    description = """
+                        소셜 서버 연동 오류로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `SOCIAL_SERVER_ERROR`: 소셜 서버로부터 정상적인 응답을 받지 못한 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "SOCIAL_SERVER_ERROR", value = "{\"code\":\"SOCIAL_SERVER_ERROR\"}")
+                    )
+            )
+    })
+    ResponseEntity<Void> deleteUser(Authentication authentication);
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/controller/OAuthController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 
 @RestController
-public class OAuthController {
+public class OAuthController implements OAuthApiDoc {
 
     private final OAuthService oauthService;
     private final UserDeletionService userDeletionService;

--- a/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/oauth/domain/OAuthProvider.java
@@ -2,7 +2,9 @@ package com.hogu.am_i_hogu.domain.oauth.domain;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.oauth.exception.OAuthErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "OAuthProvider", description = "소셜 로그인 제공자")
 public enum OAuthProvider {
     GOOGLE,
     KAKAO;

--- a/src/main/java/com/hogu/am_i_hogu/domain/policy/controller/PolicyApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/policy/controller/PolicyApiDoc.java
@@ -1,0 +1,79 @@
+package com.hogu.am_i_hogu.domain.policy.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.policy.dto.response.PolicyResponse;
+import com.hogu.am_i_hogu.domain.user.dto.response.HoguReportResponse;
+import com.hogu.am_i_hogu.domain.user.dto.response.MyPageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+
+@Tag(name = "Policy", description = "Policy API")
+public interface PolicyApiDoc {
+
+    @Operation(
+            operationId = "getPrivacyPolicy",
+            summary = "개인정보 처리 방침 조회",
+            description = "개인정보 처리 방침을 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PolicyResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "version": "v1.2.2",
+                                          "updatedAt": "2026-03-31T11:49:05",
+                                          "content": "<h1>개인정보 처리 방침</h1>...."
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PolicyResponse> getPrivacyPolicy();
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/policy/controller/PolicyController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class PolicyController {
+public class PolicyController implements PolicyApiDoc {
 
     private final PrivacyService privacyService;
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/policy/dto/response/PolicyResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/policy/dto/response/PolicyResponse.java
@@ -1,10 +1,18 @@
 package com.hogu.am_i_hogu.domain.policy.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "PolicyResponse", description = "현재 적용 중인 개인정보 처리 방침 응답")
 public record PolicyResponse(
+    @Schema(description = "정책 버전", example = "v1.0.0")
     String version,
+
+    @Schema(description = "정책 최종 수정 시각")
     LocalDateTime updatedAt,
+
+    @Schema(description = "정책 HTML 본문", example = "<h1>개인정보 처리 방침</h1>...")
     String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
@@ -1,0 +1,110 @@
+package com.hogu.am_i_hogu.domain.post.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.ImageUploadResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Post", description = "게시물 API")
+public interface ImageApiDoc {
+
+    @Operation(
+            operationId = "uploadPostImage",
+            summary = "게시물 이미지 업로드",
+            description = "게시물 등에 사용될 이미지를 업로드하고 저장된 URL을 반환한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ImageUploadResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "imageUrl": "https://..."
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `UNSUPPORTED_FORMAT`: 지원하지 않는 확장자
+                            * `EMPTY_IMAGE_FILE`: 이미지 파일 없음
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "UNSUPPORTED_FORMAT", value = "{\"code\":\"UNSUPPORTED_FORMAT\"}"),
+                                    @ExampleObject(name = "EMPTY_IMAGE_FILE", value = "{\"code\":\"EMPTY_IMAGE_FILE\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "413",
+                    description = """
+                            파일 크기 초과로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FILE_SIZE_EXCEEDED`: 파일 크기가 5MB 초과한 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FILE_SIZE_EXCEEDED", value = "{\"code\":\"FILE_SIZE_EXCEEDED\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<ImageUploadResponse> uploadImage(
+            @Parameter(
+                    description = "업로드 할 이미지 파일",
+                    required = true
+            )
+            MultipartFile image
+    );
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/images")
-public class ImageController {
+public class ImageController implements ImageApiDoc {
 
     private final ImageUploadService imageUploadService;
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostApiDoc.java
@@ -1,0 +1,1047 @@
+package com.hogu.am_i_hogu.domain.post.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.post.dto.request.HomePostSearchRequest;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostCreateRequest;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostUpdateRequest;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostVoteRequest;
+import com.hogu.am_i_hogu.domain.post.dto.response.HomePostListResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostBookmarkResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostCreateResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostUpdateResponse;
+import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Tag(name = "Post", description = "게시물 API")
+public interface PostApiDoc {
+
+    @Operation(
+            operationId = "getHomePosts",
+            summary = "홈 게시물 목록 조회",
+            description = "홈 화면 및 검색 결과에서 게시물 목록을 무한 스크롤 방식으로 조회한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = HomePostListResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "totalPostCount": 123,
+                                          "posts": [
+                                            {
+                                              "postId": 1234,
+                                              "isBookmarked": true,
+                                              "categories": ["USED_TRADE"],
+                                              "title": "제목입니다",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "viewCount": 12,
+                                              "contentPreview": "본문프리뷰입니다",
+                                              "thumbnailUrl": "https://...",
+                                              "totalVoteCount": 100,
+                                              "commentCount": 3,
+                                              "writer": {
+                                                "nickname": "hogu",
+                                                "profileImageUrl": "https://..."
+                                              }
+                                            },
+                                            {
+                                              "postId": 1235,
+                                              "isBookmarked": false,
+                                              "categories": ["USED_TRADE"],
+                                              "title": "제목입니다",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "viewCount": 12,
+                                              "contentPreview": "본문프리뷰입니다",
+                                              "thumbnailUrl": "https://...",
+                                              "totalVoteCount": 100,
+                                              "commentCount": 3,
+                                              "writer": {
+                                                "nickname": "nothogu",
+                                                "profileImageUrl": "https://..."
+                                              }
+                                            }
+                                          ],
+                                          "hasNext": true,
+                                          "nextCursor": "1E2N3C4O5D6E7D8V9A0LUE"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_PARAM_VALUE`
+                            * field: `keyword`, `categories`, `sortBy`, `cursor`
+                            * 하위 오류 코드:
+                                * 필드가 `keyword`:
+                                    * `EMPTY_KEYWORD`: 키워드가 공백으로만 이루어져 있거나 비어있는 경우
+                                * 필드가 `categories`:
+                                    * `INVALID_CATEGORIES`: 유효하지 않은 카테고리인 경우
+                                * 필드가 `sortBy`:
+                                    * `INVALID_SORTING`: 유효하지 않은 정렬 기준인 경우
+                                    * `MULTIPLE_SORTING`: 정렬 기준이 다중 선택된 경우
+                                * 필드가 `cursor`:
+                                    * `INVALID_CURSOR`: 유효하지 않은 cursor인 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "INVALID_PARAM_VALUE",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_PARAM_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "keyword",
+                                                      "code": "EMPTY_KEYWORD"
+                                                    },
+                                                    {
+                                                      "field": "sortBy",
+                                                      "code": "MULTIPLE_SORTING"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<HomePostListResponse> getHomePosts(
+            Authentication authentication,
+            @ParameterObject @ModelAttribute HomePostSearchRequest request
+    );
+
+    @Operation(
+            operationId = "getPostDetail",
+            summary = "게시물 상세 조회",
+            description = "특정 게시물의 상세 정보를 조회한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostDetailResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "postId": 1234,
+                                          "isMine": false,
+                                          "categories": ["USED_TRADE"],
+                                          "title": "안녕하세요",
+                                          "createdAt": "2026-03-31T11:49:05",
+                                          "updatedAt": "2026-03-31T11:49:05",
+                                          "viewCount": 12,
+                                          "content": "본문입니다",
+                                          "images": [
+                                            "https://...",
+                                            "https://..."
+                                          ],
+                                          "vote": {
+                                            "totalVotes": 100,
+                                            "yesVotes": 70,
+                                            "noVotes": 30,
+                                            "myVote": "HOGU"
+                                          },
+                                          "writer": {
+                                            "nickname": "hogu",
+                                            "profileImageUrl": "https://..."
+                                          }
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `WRONG_POSTID_TYPE`: 잘못된 postId 타입
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_NOT_FOUND`: 게시물이 존재하지 않음
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}"),
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostDetailResponse> getPostById(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+            Authentication authentication
+    );
+
+    @Operation(
+            operationId = "createPost",
+            summary = "게시물 생성",
+            description = "새로운 게시물을 생성한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostCreateResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "postId": 1234
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_INPUT_VALUE`
+                            * field: `title`, `categories`, `content`, `images`
+                            * 하위 오류 코드:
+                                * 필드가 `title`:
+                                    * `EMPTY_TITLE`: 제목이 공백으로만 이루어져 있거나 비어있는 경우
+                                    * `TITLE_LENGTH_EXCEEDED`: 제목 길이를 초과한 경우
+                                * 필드가 `categories`:
+                                    * `EMPTY_CATEGORIES`: 카테고리가 아무것도 선택되지 않은 경우
+                                    * `MULTIPLE_CATEGORIES`: 카테고리가 다중 선택된 경우
+                                    * `INVALID_CATEGORIES`: 존재하지 않는 카테고리인 경우
+                                * 필드가 `content`:
+                                    * `EMPTY_CONTENT`: 본문이 공백으로만 이루어져 있거나 비어있는 경우
+                                * 필드가 `images`:
+                                    * `IMAGE_COUNT_EXCEEDED`: 이미지 개수를 초과한 경우
+                                    * `INVALID_IMAGE_URL`: 이미지 URL이 유효하지 않은 경우
+                                    * `EMPTY_IMAGE_URL`: 이미지 URL이 빈 문자열인 경우
+                                    * `DUPLICATE_IMAGE_URL`: 중복된 이미지 URL이 존재하는 경우
+                                    * `EMPTY_IMAGE_ORDER`: order 필드가 없는 경우
+                                    * `EMPTY_THUMBNAIL`: 썸네일이 지정되지 않은 경우
+                                    * `MULTIPLE_THUMBNAILS`: 썸네일이 2개 이상 지정된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "title",
+                                                      "code": "EMPTY_TITLE"
+                                                    },
+                                                    {
+                                                      "field": "images",
+                                                      "code": "INVALID_IMAGE_URL"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                        사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `USER_NOT_FOUND`: 토큰은 존재하지만 DB에서 사용자 정보를 찾을 수 없는 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostCreateResponse> createPost(
+            Authentication authentication,
+            @RequestBody PostCreateRequest request
+    );
+
+    @Operation(
+            operationId = "updatePost",
+            summary = "게시물 수정",
+            description = "특정 게시물을 수정한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostUpdateResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "postId": 1234
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * 상위 오류 코드: `INVALID_INPUT_VALUE`
+                            * field: `title`, `categories`, `content`, `images`
+                            * 하위 오류 코드:
+                                * 필드가 `title`:
+                                    * `EMPTY_TITLE`: 제목이 공백으로만 이루어져 있거나 비어있는 경우
+                                    * `TITLE_LENGTH_EXCEEDED`: 제목 길이를 초과한 경우
+                                * 필드가 `categories`:
+                                    * `EMPTY_CATEGORIES`: 카테고리가 아무것도 선택되지 않은 경우
+                                    * `INVALID_CATEGORIES`: 존재하지 않는 카테고리인 경우
+                                    * `MULTIPLE_CATEGORIES`: 카테고리가 다중 선택된 경우
+                                * 필드가 `content`:
+                                    * `EMPTY_CONTENT`: 본문이 공백으로만 이루어져 있거나 비어있는 경우
+                                * 필드가 `images`:
+                                    * `IMAGE_COUNT_EXCEEDED`: 이미지 개수를 초과한 경우
+                                    * `INVALID_IMAGE_URL`: 이미지 URL이 유효하지 않은 경우
+                                    * `EMPTY_IMAGE_URL`: 이미지 URL이 빈 문자열인 경우
+                                    * `DUPLICATE_IMAGE_URL`: 중복된 이미지 URL이 존재하는 경우
+                                    * `EMPTY_IMAGE_ORDER`: order 필드가 없는 경우
+                                    * `EMPTY_THUMBNAIL`: 썸네일이 지정되지 않은 경우
+                                    * `MULTIPLE_THUMBNAILS`: 썸네일이 2개 이상 지정된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}"),
+                                    @ExampleObject(name = "EMPTY_REQUEST_BODY", value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE_TITLE",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "title",
+                                                      "code": "EMPTY_TITLE"
+                                                    },
+                                                    {
+                                                      "field": "images",
+                                                      "code": "INVALID_IMAGE_URL"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE_IMAGES",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "images",
+                                                      "code": "INVALID_IMAGE_URL"
+                                                    },
+                                                    {
+                                                      "field": "images",
+                                                      "code": "IMAGE_COUNT_EXCEEDED"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 게시물 작성자가 아닌 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostUpdateResponse> updatePost(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication,
+
+            PostUpdateRequest request
+    );
+
+    @Operation(
+            operationId = "deletePost",
+            summary = "게시물 삭제",
+            description = "특정 게시물을 삭제한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "성공"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 게시물 작성자가 아닌 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<Void> deletePost(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication
+    );
+
+    @Operation(
+            operationId = "createBookmark",
+            summary = "게시물 북마크 추가",
+            description = "특정 게시물을 북마크에 추가한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostBookmarkResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "isBookmarked": true
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = """
+                        충돌로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `DUPLICATE_REQUEST`: 이미 북마크가 등록되어 있는 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "DUPLICATE_REQUEST", value = "{\"code\":\"DUPLICATE_REQUEST\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostBookmarkResponse> createBookmark(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication
+    );
+
+    @Operation(
+            operationId = "deleteBookmark",
+            summary = "게시물 북마크 취소",
+            description = "특정 게시물에 등록한 북마크를 취소한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostBookmarkResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "isBookmarked": false
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostBookmarkResponse> deleteBookmark(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication
+    );
+
+    @Operation(
+            operationId = "updatePostVote",
+            summary = "게시물 투표 등록 및 수정",
+            description = "특정 게시물에 호구 찬성 또는 반대 투표를 등록하거나 수정한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostVoteResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "totalVotes": 100,
+                                          "yesVotes": 30,
+                                          "noVotes": 70,
+                                          "myVote": "HOGU"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            * `EMPTY_REQUEST_BODY`: 요청 본문이 비어있는 경우
+                            * `INVALID_MYVOTE`: 유효하지 않은 myVote 값
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = """
+                            권한이 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `FORBIDDEN_ACCESS`: 게시물 작성자인 경우(본인 게시물에는 투표할 수 없음)
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "FORBIDDEN_ACCESS", value = "{\"code\":\"FORBIDDEN_ACCESS\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostVoteResponse> vote(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication,
+
+            @RequestBody PostVoteRequest request
+    );
+
+    @Operation(
+            operationId = "cancelPostVote",
+            summary = "게시물 투표 취소",
+            description = "특정 게시물에 등록한 투표를 취소한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = PostVoteResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "totalVotes": 100,
+                                          "yesVotes": 30,
+                                          "noVotes": 70,
+                                          "myVote": "NONE"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                            잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `WRONG_POSTID_TYPE`: postId 타입이 잘못된 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "WRONG_POSTID_TYPE", value = "{\"code\":\"WRONG_POSTID_TYPE\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            게시물을 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `POST_ALREADY_DELETED`: 이미 삭제된 게시물인 경우
+                            * `POST_NOT_FOUND`: 게시물을 찾을 수 없는 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "POST_ALREADY_DELETED", value = "{\"code\":\"POST_ALREADY_DELETED\"}"),
+                                    @ExampleObject(name = "POST_NOT_FOUND", value = "{\"code\":\"POST_NOT_FOUND\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<PostVoteResponse> cancelVote(
+            @Parameter(
+                    name = "postId",
+                    description = "게시물 고유 식별자",
+                    in = ParameterIn.PATH,
+                    required = true
+            )
+            Long postId,
+
+            Authentication authentication
+    );
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostController.java
@@ -17,6 +17,8 @@ import com.hogu.am_i_hogu.domain.post.service.PostDeleteService;
 import com.hogu.am_i_hogu.domain.post.service.PostDetailService;
 import com.hogu.am_i_hogu.domain.post.service.PostUpdateService;
 import com.hogu.am_i_hogu.domain.post.service.PostVoteService;
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springdoc.core.annotations.ParameterObject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +28,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/posts")
-public class PostController {
+public class PostController implements PostApiDoc {
     private final PostCreateService postCreateService;
     private final PostDetailService postDetailService;
     private final PostUpdateService postUpdateService;
@@ -38,7 +40,7 @@ public class PostController {
     @GetMapping
     public ResponseEntity<HomePostListResponse> getHomePosts(
             Authentication authentication,
-            @ModelAttribute HomePostSearchRequest request
+            @ParameterObject @ModelAttribute HomePostSearchRequest request
     ) {
         Long viewerUserId = authentication == null ? null : Long.valueOf(authentication.getName());
         HomePostListResponse response = homePostQueryService.getHomePosts(viewerUserId, request);

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/HomePostSearchRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/HomePostSearchRequest.java
@@ -1,10 +1,31 @@
 package com.hogu.am_i_hogu.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "HomePostSearchRequest", description = "홈 게시물 조회 조건")
 public record HomePostSearchRequest(
+        @Schema(description = "검색 키워드", nullable = true)
         String keyword,
+
+        @Schema(
+                description = "쉼표로 구분된 카테고리 코드들",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"},
+                nullable = true
+        )
         String categories,
+
+        @Schema(
+                description = "정렬 기준",
+                allowableValues = {"LATEST", "MOST_VIEWED", "MOST_COMMENTED", "MOST_PARTICIPATED"},
+                defaultValue = "LATEST",
+                nullable = true
+        )
         String sortBy,
+
+        @Schema(description = "페이지 크기", defaultValue = "5", nullable = true)
         Integer pageSize,
+
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String cursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
@@ -11,7 +11,11 @@ public record PostCreateRequest(
         String title,
 
         @ArraySchema(
-                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                minItems = 1,
+                maxItems = 1,
+                arraySchema = @Schema(description = "카테고리 코드 목록. 1개만 허용",
+                requiredMode = Schema.RequiredMode.REQUIRED
+                ),
                 schema = @Schema(
                         type = "string",
                         allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
@@ -1,11 +1,28 @@
 package com.hogu.am_i_hogu.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "PostCreateRequest", description = "게시물 생성 요청")
 public record PostCreateRequest(
+        @Schema(description = "게시물 제목")
         String title,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                schema = @Schema(
+                        type = "string",
+                        allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+                )
+        )
         List<String> categories,
+
+        @Schema(description = "게시물 본문")
         String content,
+
+        @ArraySchema(arraySchema = @Schema(description = "이미지 목록"))
         List<PostImageRequest> images
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostImageRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostImageRequest.java
@@ -1,8 +1,16 @@
 package com.hogu.am_i_hogu.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostImageRequest", description = "게시물 이미지 요청")
 public record PostImageRequest(
+        @Schema(description = "이미지 URL")
         String imageUrl,
+
+        @Schema(description = "정렬 순서")
         Integer order,
+
+        @Schema(description = "썸네일 여부")
         Boolean isThumbnail
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostUpdateRequest.java
@@ -11,7 +11,9 @@ public record PostUpdateRequest(
         String title,
 
         @ArraySchema(
-                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                minItems = 1,
+                maxItems = 1,
+                arraySchema = @Schema(description = "변경할 카테고리 코드 목록. 1개만 허용"),
                 schema = @Schema(
                         type = "string",
                         allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostUpdateRequest.java
@@ -1,11 +1,28 @@
 package com.hogu.am_i_hogu.domain.post.dto.request;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "PostUpdateRequest", description = "게시물 수정 요청")
 public record PostUpdateRequest(
+        @Schema(description = "게시물 제목")
         String title,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                schema = @Schema(
+                        type = "string",
+                        allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+                )
+        )
         List<String> categories,
+
+        @Schema(description = "게시물 본문")
         String content,
+
+        @ArraySchema(arraySchema = @Schema(description = "이미지 목록"))
         List<PostImageRequest> images
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
@@ -1,4 +1,10 @@
 package com.hogu.am_i_hogu.domain.post.dto.request;
 
-public record PostVoteRequest(String myVote) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostVoteRequest", description = "게시물 투표 요청")
+public record PostVoteRequest(
+        @Schema(description = "투표 값", allowableValues = {"HOGU", "NOT_HOGU"})
+        String myVote
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
@@ -1,19 +1,50 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(name = "HomePostItemResponse", description = "홈 게시물 요약")
 public record HomePostItemResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+
+        @Schema(description = "북마크 여부")
         boolean isBookmarked,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                schema = @Schema(
+                        type = "string",
+                        allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+                )
+        )
         List<String> categories,
+
+        @Schema(description = "게시물 제목")
         String title,
+
+        @Schema(description = "생성 시각")
         LocalDateTime createdAt,
+
+        @Schema(description = "조회 수")
         Integer viewCount,
+
+        @Schema(description = "미리보기 본문")
         String contentPreview,
+
+        @Schema(description = "썸네일 URL", nullable = true)
         String thumbnailUrl,
+
+        @Schema(description = "총 투표 수")
         Long totalVoteCount,
+
+        @Schema(description = "댓글 수")
         Long commentCount,
+
+        @Schema(description = "작성자 정보")
         PostWriterResponse writer
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
@@ -1,14 +1,24 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(name = "HomePostListResponse", description = "홈 게시물 목록 응답")
 public record HomePostListResponse(
+        @Schema(description = "총 게시물 수", nullable = true)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         Long totalPostCount,
+
+        @ArraySchema(arraySchema = @Schema(description = "게시물 목록"))
         List<HomePostItemResponse> posts,
+
+        @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
+
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
@@ -1,4 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostBookmarkResponse", description = "게시물 북마크 응답")
 public record PostBookmarkResponse(boolean isBookmarked) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostCreateResponse.java
@@ -1,4 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostCreateResponse", description = "게시물 생성 응답")
 public record PostCreateResponse(Long postId) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
@@ -1,19 +1,50 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Schema(name = "PostDetailResponse", description = "게시물 상세 응답")
 public record PostDetailResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+
+        @Schema(description = "내가 작성한 글 여부")
         Boolean isMine,
+
+        @ArraySchema(
+                arraySchema = @Schema(description = "카테고리 코드 목록"),
+                schema = @Schema(
+                        type = "string",
+                        allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+                )
+        )
         List<String> categories,
+
+        @Schema(description = "게시물 제목")
         String title,
+
+        @Schema(description = "생성 시각")
         LocalDateTime createdAt,
+
+        @Schema(description = "수정 시각")
         LocalDateTime updatedAt,
+
+        @Schema(description = "조회 수")
         Integer viewCount,
+
+        @Schema(description = "게시물 본문")
         String content,
+
+        @ArraySchema(arraySchema = @Schema(description = "이미지 URL 목록"))
         List<String> images,
+
+        @Schema(description = "투표 정보")
         PostVoteResponse vote,
+
+        @Schema(description = "작성자 정보")
         PostWriterResponse writer
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostUpdateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostUpdateResponse.java
@@ -1,4 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostUpdateResponse", description = "게시물 수정 응답")
 public record PostUpdateResponse(Long postId) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
@@ -1,9 +1,23 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostVoteResponse", description = "게시물 투표 응답")
 public record PostVoteResponse(
+        @Schema(description = "총 투표 수")
         Integer totalVotes,
+
+        @Schema(description = "호구예요 수")
         Integer yesVotes,
+
+        @Schema(description = "호구아니에요 수")
         Integer noVotes,
+
+        @Schema(
+                description = "내 투표 값",
+                allowableValues = {"HOGU", "NOT_HOGU", "NONE"},
+                nullable = true
+        )
         String myVote
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostWriterResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostWriterResponse.java
@@ -1,7 +1,13 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PostWriterResponse", description = "게시물 작성자 정보")
 public record PostWriterResponse(
+        @Schema(description = "닉네임")
         String nickname,
+
+        @Schema(description = "프로필 이미지 URL", nullable = true)
         String profileImageUrl
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserApiDoc.java
@@ -505,7 +505,6 @@ public interface UserApiDoc {
                     responseCode = "400",
                     description = """
                         잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
-                        
                         * `INVALID_CURSOR`: 유효하지 않은 cursor 값인 경우
                         """,
                     content = @Content(

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserApiDoc.java
@@ -1,0 +1,904 @@
+package com.hogu.am_i_hogu.domain.user.controller;
+
+import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
+import com.hogu.am_i_hogu.domain.user.dto.request.UpdateProfileRequest;
+import com.hogu.am_i_hogu.domain.user.dto.response.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "User", description = "유저 API")
+public interface UserApiDoc {
+
+    @Operation(
+            operationId = "updateProfile",
+            summary = "프로필 수정",
+            description = "사용자의 닉네임 또는 프로필 이미지를 수정한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UpdateProfileResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "SUCCESS_WITH_IMAGE_UPDATE",
+                                            summary = "이미지 업데이트 하는 경우",
+                                            value = """
+                                                {
+                                                  "id": 1,
+                                                  "nickname": "hogu123",
+                                                  "profileImageUrl": "https://..."
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "SUCCESS_WITH_IMAGE_DELETE",
+                                            summary = "이미지 삭제하는 경우",
+                                            value = """
+                                                {
+                                                  "id": 1,
+                                                  "nickname": "hogu123",
+                                                  "profileImageUrl": null
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "SUCCESS_WITHOUT_IMAGE",
+                                            summary = "이미지 유지하는 경우",
+                                            value = """
+                                                {
+                                                  "id": 1,
+                                                  "nickname": "hogu123"
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `EMPTY_REQUEST_BODY`: 요청 필드가 비어있음
+                        * `INVALID_INPUT_VALUE`: 요청 필드 유효성 검사 실패 (닉네임 길이 초과, 공백, 특수문자 및 이미지 URL 오류 등)
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "EMPTY_REQUEST_BODY",
+                                            value = "{\"code\":\"EMPTY_REQUEST_BODY\"}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE_1",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "EMPTY_NICKNAME"
+                                                    },
+                                                    {
+                                                      "field": "images",
+                                                      "code": "INVALID_IMAGE_URL"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "INVALID_INPUT_VALUE_2",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_INPUT_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "SPECIAL_CHAR_NICKNAME"
+                                                    },
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "NICKNAME_LENGTH_EXCEEDED"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                        사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `USER_NOT_FOUND`: 존재하지 않는 사용자인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = """
+                        충돌로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `DUPLICATE_NICKNAME`: 닉네임이 중복된 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "DUPLICATE_NICKNAME", value = "{\"code\":\"DUPLICATE_NICKNAME\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<UpdateProfileResponse> updateProfile(
+            Authentication authentication,
+            @RequestBody(required = false) UpdateProfileRequest request
+    );
+
+    @Operation(
+            operationId = "checkNickname",
+            summary = "닉네임 중복 검사",
+            description = "사용하고자 하는 닉네임의 중복 여부 및 유효성을 검사한다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CheckNicknameResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "AVAILABLE",
+                                            summary = "사용 가능",
+                                            value = """
+                                                {
+                                                  "isAvailable": true
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "DUPLICATE",
+                                            summary = "사용 불가능 (중복)",
+                                            value = """
+                                                {
+                                                  "isAvailable": false
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * 상위 오류 코드: `INVALID_PARAM_VALUE`
+                        * field: `nickname`
+                        * 하위 오류 코드:
+                            * `EMPTY_NICKNAME`: 닉네임이 공백으로만 이루어져 있거나 비어있는 경우
+                            * `SPECIAL_CHAR_NICKNAME`: 닉네임에 특수문자가 포함되어 있는 경우
+                            * `NICKNAME_LENGTH_EXCEEDED`: 닉네임 길이가 부족하거나 초과된 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "EMPTY_NICKNAME",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_PARAM_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "EMPTY_NICKNAME"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    ),
+                                    @ExampleObject(
+                                            name = "MULTIPLE_ERRORS",
+                                            value = """
+                                                {
+                                                  "code": "INVALID_PARAM_VALUE",
+                                                  "errors": [
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "SPECIAL_CHAR_NICKNAME"
+                                                    },
+                                                    {
+                                                      "field": "nickname",
+                                                      "code": "NICKNAME_LENGTH_EXCEEDED"
+                                                    }
+                                                  ]
+                                                }
+                                                """
+                                    )
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<CheckNicknameResponse> checkNickname(
+            @Parameter(
+                    name = "nickname",
+                    description = "중복 검사할 닉네임",
+                    in = ParameterIn.QUERY,
+                    required = true
+            )
+            @RequestParam(name="nickname", required = false) String nickname
+    );
+
+    @Operation(
+            operationId = "getMyPage",
+            summary = "마이페이지 조회",
+            description = "사용자의 마이페이지 정보를 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MyPageResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "nickname": "민돌이",
+                                          "profileImageUrl": "https://...",
+                                          "hoguIndex": 60,
+                                          "hoguLevel": "RISKY",
+                                          "hoguShortDescription": "거절보다 양보가 앞서는 타입"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                        사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `USER_NOT_FOUND`: 토큰은 존재하지만 DB에서 사용자 정보를 찾을 수 없는 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<MyPageResponse> getMyPage(Authentication authentication);
+
+    @Operation(
+            operationId = "getHoguReport",
+            summary = "호구 리포트 조회",
+            description = "사용자의 호구 리포트 정보를 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = HoguReportResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "nickname": "민돌이",
+                                          "profileImageUrl": "https://...",
+                                          "hoguIndex": 60,
+                                          "hoguLevel": "RISKY",
+                                          "hoguShortDescription": "거절보다 양보가 앞서는 타입",
+                                          "hoguDescription": "평소에는 괜찮지만, 상대가 강하게 나오거나 관계가 신경 쓰이는 상황에서 본인 기준이 흔들릴 수 있어요. 결정 전에 '내가 감당할 손해인가?'를 한 번 체크해보세요.",
+                                          "categoryAnalysis": [
+                                            {
+                                              "category": "DATING",
+                                              "hoguIndex": 80,
+                                              "hoguLevel": "CRITICAL"
+                                            },
+                                            {
+                                              "category": "USED_TRADE",
+                                              "hoguIndex": 40,
+                                              "hoguLevel": "WARNING"
+                                            }
+                                          ],
+                                          "totalPostCount": 12,
+                                          "hoguPostCount": 8,
+                                          "notHoguPostCount": 4
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                        사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * `USER_NOT_FOUND`: 토큰은 존재하지만 DB에서 사용자 정보를 찾을 수 없는 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<HoguReportResponse> getHoguReport(Authentication authentication);
+
+    @Operation(
+            operationId = "getMyPosts",
+            summary = "내가 쓴 게시물 목록 조회",
+            description = "사용자가 작성한 게시물 목록을 무한 스크롤 방식으로 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MyPostListResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "posts": [
+                                            {
+                                              "postId": 123,
+                                              "title": "내가 쓴 첫 번재 글",
+                                              "category": "USED_TRADE",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "voteSummary": "HOGU",
+                                              "commentCount": 1
+                                            },
+                                            {
+                                              "postId": 1234,
+                                              "title": "내가 쓴 두 번재 글",
+                                              "category": "USED_TRADE",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "voteSummary": "NONE",
+                                              "commentCount": 2
+                                            }
+                                          ],
+                                          "hasNext": false,
+                                          "nextCursor": "DKLJEI2JDLKJ"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        
+                        * `INVALID_CURSOR`: 유효하지 않은 cursor 값인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "INVALID_PARAM_VALUE",
+                                    value = """
+                                        {
+                                          "code": "INVALID_PARAM_VALUE",
+                                          "errors": [
+                                            {
+                                              "field": "cursor",
+                                              "code": "INVALID_CURSOR"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<MyPostListResponse> getMyPosts(
+            Authentication authentication,
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
+    );
+
+    @Operation(
+            operationId = "getMyComments",
+            summary = "내가 쓴 댓글(집단지성) 목록 조회",
+            description = "사용자가 작성한 댓글(집단지성) 목록을 무한 스크롤 방식으로 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MyCommentListResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "comments": [
+                                            {
+                                              "commentId": 1234,
+                                              "content": "나의 첫 번째 댓글",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "post": {
+                                                "postId": 12,
+                                                "title": "집단지성이 포함된 게시물의 제목입니다.",
+                                                "category": "USED_TRADE",
+                                                "commentCount": 123,
+                                                "isDeleted": false
+                                              }
+                                            },
+                                            {
+                                              "commentId": 123,
+                                              "content": "나의 두 번째 댓글",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "post": {
+                                                "postId": 12344,
+                                                "title": "집단지성이 포함된 게시물의 제목입니다.",
+                                                "category": "USED_TRADE",
+                                                "commentCount": 123,
+                                                "isDeleted": false
+                                              }
+                                            }
+                                          ],
+                                          "hasNext": false,
+                                          "nextCursor": "DLKJEIU4KJDI29"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * 상위 오류 코드: `INVALID_PARAM_VALUE'
+                        * field: `cursor`
+                        * 하위 오류 코드:
+                            * `INVALID_CURSOR`: 유효하지 않은 cursor 값인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "INVALID_PARAM_VALUE",
+                                    value = """
+                                        {
+                                          "code": "INVALID_PARAM_VALUE",
+                                          "errors": [
+                                            {
+                                              "field": "cursor",
+                                              "code": "INVALID_CURSOR"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<MyCommentListResponse> getMyComments(
+            Authentication authentication,
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
+    );
+
+    @Operation(
+            operationId = "getMyBookmarks",
+            summary = "내가 북마크한 게시물 목록 조회",
+            description = "사용자가 북마크한 게시물 목록을 무한 스크롤 방식으로 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MyBookmarkListResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "posts": [
+                                            {
+                                              "postId": 123,
+                                              "title": "내가 쓴 첫 번재 글",
+                                              "category": "USED_TRADE",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "voteSummary": "HOGU",
+                                              "commentCount": 1,
+                                              "isDeleted": false
+                                            },
+                                            {
+                                              "postId": 1234,
+                                              "title": "내가 쓴 두 번재 글",
+                                              "category": "USED_TRADE",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "voteSummary": "NONE",
+                                              "commentCount": 2,
+                                              "isDeleted": false
+                                            }
+                                          ],
+                                          "hasNext": false,
+                                          "nextCursor": "DLKJREIU2"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * 상위 오류 코드: `INVALID_PARAM_VALUE'
+                        * field: `cursor`
+                        * 하위 오류 코드:
+                            * `INVALID_CURSOR`: 유효하지 않은 cursor 값인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "INVALID_PARAM_VALUE",
+                                    value = """
+                                        {
+                                          "code": "INVALID_PARAM_VALUE",
+                                          "errors": [
+                                            {
+                                              "field": "cursor",
+                                              "code": "INVALID_CURSOR"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<MyBookmarkListResponse> getMyBookmarks(
+            Authentication authentication,
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
+    );
+
+    @Operation(
+            operationId = "getMyVotes",
+            summary = "내가 투표한 게시물 목록 조회",
+            description = "사용자가 투표한 게시물 목록을 무한 스크롤 방식으로 조회한다.",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = MyVoteListResponse.class),
+                            examples = @ExampleObject(
+                                    value = """
+                                        {
+                                          "votes": [
+                                            {
+                                              "myVote": "HOGU",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "post": {
+                                                "postId": 123,
+                                                "title": "첫 번째로 투표한 게시물의 제목입니다.",
+                                                "category": "USED_TRADE",
+                                                "commentCount": 1,
+                                                "isDeleted": false
+                                              }
+                                            },
+                                            {
+                                              "myVote": "HOGU",
+                                              "createdAt": "2026-03-31T11:49:05",
+                                              "post": {
+                                                "postId": 412,
+                                                "title": "두 번째로 투표한 게시물의 제목입니다.",
+                                                "category": "USED_TRADE",
+                                                "commentCount": 0,
+                                                "isDeleted": false
+                                              }
+                                            }
+                                          ],
+                                          "hasNext": false,
+                                          "nextCursor": "DLDUFKJ3"
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = """
+                        잘못된 요청으로 인해 실패한다. 다음 오류 코드가 발생할 수 있다:
+                        * 상위 오류 코드: `INVALID_PARAM_VALUE'
+                        * field: `cursor`
+                        * 하위 오류 코드:
+                            * `INVALID_CURSOR`: 유효하지 않은 cursor 값인 경우
+                        """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(
+                                    name = "INVALID_PARAM_VALUE",
+                                    value = """
+                                        {
+                                          "code": "INVALID_PARAM_VALUE",
+                                          "errors": [
+                                            {
+                                              "field": "cursor",
+                                              "code": "INVALID_CURSOR"
+                                            }
+                                          ]
+                                        }
+                                        """
+                            )
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = """
+                            access token 관련 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `ACCESS_TOKEN_EXPIRED`: access token이 만료된 경우
+                            * `EMPTY_ACCESS_TOKEN`: access token이 없는 경우
+                            * `INVALID_ACCESS_TOKEN`: access token이 유효하지 않은 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "ACCESS_TOKEN_EXPIRED", value = "{\"code\":\"ACCESS_TOKEN_EXPIRED\"}"),
+                                    @ExampleObject(name = "EMPTY_ACCESS_TOKEN", value = "{\"code\":\"EMPTY_ACCESS_TOKEN\"}"),
+                                    @ExampleObject(name = "INVALID_ACCESS_TOKEN", value = "{\"code\":\"INVALID_ACCESS_TOKEN\"}")
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = """
+                    서버 오류로 실패한다. 다음 오류 코드가 발생할 수 있다:
+                    * `SERVER_ERROR`: 서버 오류
+                    """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = {
+                                    @ExampleObject(name = "SERVER_ERROR", value = "{\"code\":\"SERVER_ERROR\"}"),
+                            }
+                    )
+            )
+    })
+    ResponseEntity<MyVoteListResponse> getMyVotes(
+            Authentication authentication,
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
+    );
+}

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.hogu.am_i_hogu.domain.user.dto.request.CursorRequest;
 import com.hogu.am_i_hogu.domain.user.dto.request.UpdateProfileRequest;
 import com.hogu.am_i_hogu.domain.user.dto.response.*;
 import com.hogu.am_i_hogu.domain.user.service.*;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
-public class UserController {
+public class UserController implements UserApiDoc {
     private final NicknameCheckService nicknameCheckService;
     private final ProfileUpdateService profileUpdateService;
     private final MyPostQueryService myPostQueryService;
@@ -114,7 +115,7 @@ public class UserController {
     @GetMapping("/me/posts")
     public ResponseEntity<MyPostListResponse> getMyPosts(
             Authentication authentication,
-            @ModelAttribute CursorRequest cursorRequest
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
     ) {
         Long userId = Long.valueOf(authentication.getName());
         MyPostListResponse response = myPostQueryService.getMyPosts(userId, cursorRequest);
@@ -132,7 +133,7 @@ public class UserController {
     @GetMapping("/me/comments")
     public ResponseEntity<MyCommentListResponse> getMyComments(
             Authentication authentication,
-            @ModelAttribute CursorRequest cursorRequest
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
     ) {
         Long userId = Long.valueOf(authentication.getName());
         MyCommentListResponse response = myCommentQueryService.getMyComments(userId, cursorRequest);
@@ -150,7 +151,7 @@ public class UserController {
     @GetMapping("/me/bookmarks")
     public ResponseEntity<MyBookmarkListResponse> getMyBookmarks(
             Authentication authentication,
-            @ModelAttribute CursorRequest cursorRequest
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
     ) {
         Long userId = Long.valueOf(authentication.getName());
         MyBookmarkListResponse response = myBookmarkQueryService.getMyBookmarks(userId, cursorRequest);
@@ -168,7 +169,7 @@ public class UserController {
     @GetMapping("/me/votes")
     public ResponseEntity<MyVoteListResponse> getMyVotes(
             Authentication authentication,
-            @ModelAttribute CursorRequest cursorRequest
+            @ParameterObject @ModelAttribute CursorRequest cursorRequest
     ) {
         Long userId = Long.valueOf(authentication.getName());
         MyVoteListResponse response = myVoteQueryService.getMyVotes(userId, cursorRequest);

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/CursorRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/CursorRequest.java
@@ -1,7 +1,12 @@
 package com.hogu.am_i_hogu.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UserCursorRequest", description = "사용자 내역 조회 커서 요청")
 public record CursorRequest(
+        @Schema(description = "페이지 크기", defaultValue = "5", nullable = true)
         Integer pageSize,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String cursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/UpdateProfileRequest.java
@@ -1,9 +1,14 @@
 package com.hogu.am_i_hogu.domain.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.openapitools.jackson.nullable.JsonNullable;
 
+@Schema(name = "UpdateProfileRequest", description = "프로필 수정 요청. 최소 1개 이상의 필드는 반드시 포함되어야 한다.")
 public record UpdateProfileRequest (
+        @Schema(description = "설정하고자 하는 닉네임", nullable = true)
         String nickname,
+
+        @Schema(description = "설정하고자 하는 프로필 이미지 URL. null이면 삭제 의미, 필드 미포함 시 이미지 유지 의미", nullable = true)
         JsonNullable<String> profileImageUrl
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CategoryAnalysisResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CategoryAnalysisResponse.java
@@ -1,8 +1,20 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CategoryAnalysisResponse", description = "카테고리별 호구 분석 응답")
 public record CategoryAnalysisResponse(
+        @Schema(
+                description = "카테고리 코드",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+        )
         String category,
+        @Schema(description = "카테고리별 호구 지수", example = "60")
         Integer hoguIndex,
+        @Schema(
+                description = "카테고리별 호구 레벨 코드",
+                allowableValues = {"SAFE", "CAUTIOUS", "WARNING", "RISKY", "CRITICAL", "NONE"}
+        )
         String hoguLevel
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CheckNicknameResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CheckNicknameResponse.java
@@ -1,4 +1,10 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
-public record CheckNicknameResponse (boolean isAvailable){
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CheckNicknameResponse", description = "닉네임 중복 검사 응답")
+public record CheckNicknameResponse(
+        @Schema(description = "닉네임 사용 가능 여부")
+        boolean isAvailable
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/HoguReportResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/HoguReportResponse.java
@@ -1,17 +1,34 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "HoguReportResponse", description = "호구 보고서 응답")
 public record HoguReportResponse(
+        @Schema(description = "닉네임")
         String nickname,
+        @Schema(description = "프로필 이미지 URL", nullable = true)
         String profileImageUrl,
+        @Schema(description = "호구 지수")
         Integer hoguIndex,
+        @Schema(
+                description = "호구 레벨 코드",
+                allowableValues = {"SAFE", "CAUTIOUS", "WARNING", "RISKY", "CRITICAL", "NONE"}
+        )
         String hoguLevel,
+        @Schema(description = "호구 레벨 한 줄 설명")
         String hoguShortDescription,
+        @Schema(description = "호구 레벨 상세 설명")
         String hoguDescription,
+        @ArraySchema(arraySchema = @Schema(description = "카테고리별 분석 결과"))
         List<CategoryAnalysisResponse> categoryAnalysis,
+        @Schema(description = "전체 게시물 수")
         Integer totalPostCount,
+        @Schema(description = "호구 판정 게시물 수")
         Integer hoguPostCount,
+        @Schema(description = "호구 아님 판정 게시물 수")
         Integer notHoguPostCount
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkItemResponse.java
@@ -1,14 +1,30 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "MyBookmarkItemResponse", description = "내 북마크 게시물 항목")
 public record MyBookmarkItemResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+        @Schema(description = "게시물 제목")
         String title,
+        @Schema(
+                description = "카테고리 코드",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+        )
         String category,
+        @Schema(description = "북마크 생성 시각")
         LocalDateTime createdAt,
+        @Schema(
+                description = "투표 요약",
+                allowableValues = {"HOGU", "NOT_HOGU", "NONE", "TIE"}
+        )
         String voteSummary,
+        @Schema(description = "댓글 수")
         long commentCount,
+        @Schema(description = "게시물 삭제 여부")
         boolean isDeleted
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkListResponse.java
@@ -1,10 +1,17 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "MyBookmarkListResponse", description = "내 북마크 게시물 목록 응답")
 public record MyBookmarkListResponse(
+        @ArraySchema(arraySchema = @Schema(description = "북마크 게시물 목록"))
         List<MyBookmarkItemResponse> posts,
+        @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentItemResponse.java
@@ -1,11 +1,18 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "MyCommentItemResponse", description = "내 댓글 항목")
 public record MyCommentItemResponse(
+        @Schema(description = "댓글 ID")
         Long commentId,
+        @Schema(description = "댓글 내용")
         String content,
+        @Schema(description = "댓글 작성 시각")
         LocalDateTime createdAt,
+        @Schema(description = "댓글이 달린 게시물 정보")
         MyCommentPostResponse post
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentListResponse.java
@@ -1,10 +1,17 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "MyCommentListResponse", description = "내 댓글 목록 응답")
 public record MyCommentListResponse(
+        @ArraySchema(arraySchema = @Schema(description = "댓글 목록"))
         List<MyCommentItemResponse> comments,
+        @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentPostResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentPostResponse.java
@@ -1,10 +1,21 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MyCommentPostResponse", description = "내 댓글 대상 게시물 정보")
 public record MyCommentPostResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+        @Schema(description = "게시물 제목")
         String title,
+        @Schema(
+                description = "카테고리 코드",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+        )
         String category,
+        @Schema(description = "댓글 수")
         long commentCount,
+        @Schema(description = "게시물 삭제 여부")
         boolean isDeleted
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPageResponse.java
@@ -1,10 +1,21 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MyPageResponse", description = "마이페이지 응답")
 public record MyPageResponse(
+        @Schema(description = "닉네임")
         String nickname,
+        @Schema(description = "프로필 이미지 URL", nullable = true)
         String profileImageUrl,
+        @Schema(description = "호구 지수")
         Integer hoguIndex,
+        @Schema(
+                description = "호구 레벨 코드",
+                allowableValues = {"SAFE", "CAUTIOUS", "WARNING", "RISKY", "CRITICAL", "NONE"}
+        )
         String hoguLevel,
+        @Schema(description = "호구 레벨 한 줄 설명")
         String hoguShortDescription
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostItemResponse.java
@@ -1,13 +1,28 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "MyPostItemResponse", description = "내 게시물 항목")
 public record MyPostItemResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+        @Schema(description = "게시물 제목")
         String title,
+        @Schema(
+                description = "카테고리 코드",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+        )
         String category,
+        @Schema(description = "게시물 작성 시각")
         LocalDateTime createdAt,
+        @Schema(
+                description = "투표 요약",
+                allowableValues = {"HOGU", "NOT_HOGU", "NONE", "TIE"}
+        )
         String voteSummary,
+        @Schema(description = "댓글 수")
         long commentCount
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostListResponse.java
@@ -1,10 +1,17 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "MyPostListResponse", description = "내 게시물 목록 응답")
 public record MyPostListResponse(
+    @ArraySchema(arraySchema = @Schema(description = "게시물 목록"))
     List<MyPostItemResponse> posts,
+    @Schema(description = "다음 페이지 존재 여부")
     boolean hasNext,
+    @Schema(description = "다음 페이지 커서", nullable = true)
     String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteItemResponse.java
@@ -1,10 +1,19 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
+@Schema(name = "MyVoteItemResponse", description = "내 투표 항목")
 public record MyVoteItemResponse(
+        @Schema(
+                description = "내 투표 값",
+                allowableValues = {"HOGU", "NOT_HOGU"}
+        )
         String myVote,
+        @Schema(description = "투표 시각")
         LocalDateTime createdAt,
+        @Schema(description = "투표한 게시물 정보")
         MyVotePostResponse post
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteListResponse.java
@@ -1,10 +1,17 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
+@Schema(name = "MyVoteListResponse", description = "내 투표 목록 응답")
 public record MyVoteListResponse(
+        @ArraySchema(arraySchema = @Schema(description = "투표 목록"))
         List<MyVoteItemResponse> votes,
+        @Schema(description = "다음 페이지 존재 여부")
         boolean hasNext,
+        @Schema(description = "다음 페이지 커서", nullable = true)
         String nextCursor
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVotePostResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVotePostResponse.java
@@ -1,10 +1,21 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MyVotePostResponse", description = "내 투표 대상 게시물 정보")
 public record MyVotePostResponse(
+        @Schema(description = "게시물 ID")
         Long postId,
+        @Schema(description = "게시물 제목")
         String title,
+        @Schema(
+                description = "카테고리 코드",
+                allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}
+        )
         String category,
+        @Schema(description = "댓글 수")
         long commentCount,
+        @Schema(description = "게시물 삭제 여부")
         boolean isDeleted
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/UpdateProfileResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/UpdateProfileResponse.java
@@ -1,8 +1,16 @@
 package com.hogu.am_i_hogu.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UpdateProfileResponse", description = "프로필 수정 응답")
 public record UpdateProfileResponse (
+        @Schema(description = "유저를 구분하는 고유의 id")
         Long id,
+
+        @Schema(description = "유저가 설정한 닉네임")
         String nickname,
+
+        @Schema(description = "프로필 이미지 URL. 프로필 이미지가 삭제되었거나 없는 경우 null", nullable = true)
         String profileImageUrl
 ) {
 }

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -21,6 +21,8 @@ server:
 serverName: blue_server
 
 app:
+  openapi:
+    server-uri: http://43.201.237.252
   redirect:
     # 프론트 배포 전 임시값. 프론트 배포 후 FRONTEND_URL을 실제 주소로 설정한다.
     onboarding-uri: ${FRONTEND_URL:http://localhost:3000}/onboarding

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -25,9 +25,16 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
+springdoc:
+  api-docs:
+    version: OPENAPI_3_0
+
 app:
   cookie:
     secure: true
+  openapi:
+    title: am-i-hogu API
+    version: v1
 
 # aws s3 bucket
 cloud:

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -21,6 +21,8 @@ server:
 serverName: green_server
 
 app:
+  openapi:
+    server-uri: http://43.201.237.252
   redirect:
     # 프론트 배포 전 임시값. 프론트 배포 후 FRONTEND_URL을 실제 주소로 설정한다.
     onboarding-uri: ${FRONTEND_URL:http://localhost:3000}/onboarding

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -23,6 +23,8 @@ serverName: local_server
 app:
   cookie:
     secure: false
+  openapi:
+    server-uri: http://localhost:8080
   redirect:
     # local test를 위한 uri이기 때문에 port를 8080으로 설정
     onboarding-uri: http://localhost:8080/api/users

--- a/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
@@ -41,12 +41,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.configuration.SpringDocSecurityConfiguration;
@@ -90,35 +91,36 @@ class OpenApiGenerationVerificationTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean private PostCreateService postCreateService;
-    @MockBean private PostDetailService postDetailService;
-    @MockBean private PostUpdateService postUpdateService;
-    @MockBean private PostDeleteService postDeleteService;
-    @MockBean private PostBookmarkService postBookmarkService;
-    @MockBean private PostVoteService postVoteService;
-    @MockBean private HomePostQueryService homePostQueryService;
-    @MockBean private CommentCreateService commentCreateService;
-    @MockBean private CommentReadService commentReadService;
-    @MockBean private CommentUpdateService commentUpdateService;
-    @MockBean private CommentDeleteService commentDeleteService;
-    @MockBean private CommentHelpfulService commentHelpfulService;
-    @MockBean private OnboardingService onboardingService;
-    @MockBean private ReissueService reissueService;
-    @MockBean private LogoutService logoutService;
-    @MockBean private OAuthService oauthService;
-    @MockBean private UserDeletionService userDeletionService;
-    @MockBean private JwtProvider jwtProvider;
-    @MockBean private UserRepository userRepository;
-    @MockBean private AuthenticationEntryPoint authenticationEntryPoint;
-    @MockBean private AccessDeniedHandler accessDeniedHandler;
-    @MockBean private NicknameCheckService nicknameCheckService;
-    @MockBean private ProfileUpdateService profileUpdateService;
-    @MockBean private MyPostQueryService myPostQueryService;
-    @MockBean private MyCommentQueryService myCommentQueryService;
-    @MockBean private MyBookmarkQueryService myBookmarkQueryService;
-    @MockBean private MyVoteQueryService myVoteQueryService;
-    @MockBean private MyPageService myPageService;
-    @MockBean private HoguReportService hoguReportService;
+    @MockitoBean
+    private PostCreateService postCreateService;
+    @MockitoBean private PostDetailService postDetailService;
+    @MockitoBean private PostUpdateService postUpdateService;
+    @MockitoBean private PostDeleteService postDeleteService;
+    @MockitoBean private PostBookmarkService postBookmarkService;
+    @MockitoBean private PostVoteService postVoteService;
+    @MockitoBean private HomePostQueryService homePostQueryService;
+    @MockitoBean private CommentCreateService commentCreateService;
+    @MockitoBean private CommentReadService commentReadService;
+    @MockitoBean private CommentUpdateService commentUpdateService;
+    @MockitoBean private CommentDeleteService commentDeleteService;
+    @MockitoBean private CommentHelpfulService commentHelpfulService;
+    @MockitoBean private OnboardingService onboardingService;
+    @MockitoBean private ReissueService reissueService;
+    @MockitoBean private LogoutService logoutService;
+    @MockitoBean private OAuthService oauthService;
+    @MockitoBean private UserDeletionService userDeletionService;
+    @MockitoBean private JwtProvider jwtProvider;
+    @MockitoBean private UserRepository userRepository;
+    @MockitoBean private AuthenticationEntryPoint authenticationEntryPoint;
+    @MockitoBean private AccessDeniedHandler accessDeniedHandler;
+    @MockitoBean private NicknameCheckService nicknameCheckService;
+    @MockitoBean private ProfileUpdateService profileUpdateService;
+    @MockitoBean private MyPostQueryService myPostQueryService;
+    @MockitoBean private MyCommentQueryService myCommentQueryService;
+    @MockitoBean private MyBookmarkQueryService myBookmarkQueryService;
+    @MockitoBean private MyVoteQueryService myVoteQueryService;
+    @MockitoBean private MyPageService myPageService;
+    @MockitoBean private HoguReportService hoguReportService;
 
     @Test
     void apiDocs_and_typescriptFetch_generation_are_valid(@TempDir Path tempDir) throws Exception {
@@ -143,13 +145,11 @@ class OpenApiGenerationVerificationTest {
         Files.createDirectories(outputDir);
 
         Process process = new ProcessBuilder(List.of(
-                "docker", "run", "--rm",
-                "-v", tempDir.toAbsolutePath() + ":/local",
-                "openapitools/openapi-generator-cli:v7.13.0",
-                "generate",
-                "-i", "/local/api-docs.json",
-                "-g", "typescript-fetch",
-                "-o", "/local/typescript-fetch"
+                "sh", "-c",
+                String.format(
+                        "docker run --rm -u $(id -u):$(id -g) -v %s:/local openapitools/openapi-generator-cli:v7.13.0 generate -i /local/api-docs.json -g typescript-fetch -o /local/typescript-fetch",
+                        tempDir.toAbsolutePath()
+                )
         )).redirectErrorStream(true).start();
 
         String generatorOutput = new String(process.getInputStream().readAllBytes());

--- a/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
@@ -17,6 +17,8 @@ import com.hogu.am_i_hogu.domain.comment.service.CommentUpdateService;
 import com.hogu.am_i_hogu.domain.oauth.controller.OAuthController;
 import com.hogu.am_i_hogu.domain.oauth.service.OAuthService;
 import com.hogu.am_i_hogu.domain.oauth.service.UserDeletionService;
+import com.hogu.am_i_hogu.domain.policy.controller.PolicyController;
+import com.hogu.am_i_hogu.domain.policy.service.PrivacyService;
 import com.hogu.am_i_hogu.domain.post.controller.PostController;
 import com.hogu.am_i_hogu.domain.post.service.HomePostQueryService;
 import com.hogu.am_i_hogu.domain.post.service.PostBookmarkService;
@@ -68,7 +70,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         CommentController.class,
         AuthController.class,
         OAuthController.class,
-        UserController.class
+        UserController.class,
+        PolicyController.class
 })
 @AutoConfigureMockMvc(addFilters = false)
 @Import({
@@ -121,6 +124,7 @@ class OpenApiGenerationVerificationTest {
     @MockitoBean private MyVoteQueryService myVoteQueryService;
     @MockitoBean private MyPageService myPageService;
     @MockitoBean private HoguReportService hoguReportService;
+    @MockitoBean private PrivacyService privacyService;
 
     @Test
     void apiDocs_and_typescriptFetch_generation_are_valid(@TempDir Path tempDir) throws Exception {
@@ -136,6 +140,17 @@ class OpenApiGenerationVerificationTest {
         assertThat(root.get("paths").get("/api/posts/{postId}").get("get").get("operationId").asText()).isEqualTo("getPostDetail");
         assertThat(root.get("paths").get("/api/posts/{postId}/comments").get("post").get("operationId").asText()).isEqualTo("createComment");
         assertThat(root.get("paths").get("/api/auth/login/{provider}").get("get").get("operationId").asText()).isEqualTo("login");
+        assertThat(root.get("paths").get("/api/auth/callback/{provider}").get("get").get("operationId").asText()).isEqualTo("handleOAuthCallback");
+        assertThat(root.get("paths").get("/api/users/me").get("delete").get("operationId").asText()).isEqualTo("deleteUser");
+        assertThat(root.get("paths").get("/api/users/me").get("patch").get("operationId").asText()).isEqualTo("updateProfile");
+        assertThat(root.get("paths").get("/api/users/check-nickname").get("get").get("operationId").asText()).isEqualTo("checkNickname");
+        assertThat(root.get("paths").get("/api/users/me").get("get").get("operationId").asText()).isEqualTo("getMyPage");
+        assertThat(root.get("paths").get("/api/users/me/report").get("get").get("operationId").asText()).isEqualTo("getHoguReport");
+        assertThat(root.get("paths").get("/api/users/me/posts").get("get").get("operationId").asText()).isEqualTo("getMyPosts");
+        assertThat(root.get("paths").get("/api/users/me/comments").get("get").get("operationId").asText()).isEqualTo("getMyComments");
+        assertThat(root.get("paths").get("/api/users/me/bookmarks").get("get").get("operationId").asText()).isEqualTo("getMyBookmarks");
+        assertThat(root.get("paths").get("/api/users/me/votes").get("get").get("operationId").asText()).isEqualTo("getMyVotes");
+        assertThat(root.get("paths").get("/api/policies/privacy").get("get").get("operationId").asText()).isEqualTo("getPrivacyPolicy");
         assertThat(root.at("/components/securitySchemes/bearerAuth/type").asText()).isEqualTo("http");
 
         Path specFile = tempDir.resolve("api-docs.json");
@@ -162,27 +177,41 @@ class OpenApiGenerationVerificationTest {
         Path oauthApi = outputDir.resolve("apis/OAuthApi.ts");
         Path postApi = outputDir.resolve("apis/PostApi.ts");
         Path commentApi = outputDir.resolve("apis/CommentApi.ts");
+        Path userApi = outputDir.resolve("apis/UserApi.ts");
+        Path policyApi = outputDir.resolve("apis/PolicyApi.ts");
         Path postVoteRequest = outputDir.resolve("models/PostVoteRequest.ts");
         Path homePostListResponse = outputDir.resolve("models/HomePostListResponse.ts");
+        Path policyResponse = outputDir.resolve("models/PolicyResponse.ts");
+        Path updateProfileResponse = outputDir.resolve("models/UpdateProfileResponse.ts");
 
         assertThat(authApi).exists();
         assertThat(oauthApi).exists();
         assertThat(postApi).exists();
         assertThat(commentApi).exists();
+        assertThat(userApi).exists();
+        assertThat(policyApi).exists();
         assertThat(postVoteRequest).exists();
         assertThat(homePostListResponse).exists();
+        assertThat(policyResponse).exists();
+        assertThat(updateProfileResponse).exists();
 
         String authApiContent = Files.readString(authApi);
         String oauthApiContent = Files.readString(oauthApi);
         String postApiContent = Files.readString(postApi);
         String commentApiContent = Files.readString(commentApi);
+        String userApiContent = Files.readString(userApi);
+        String policyApiContent = Files.readString(policyApi);
         String postVoteRequestContent = Files.readString(postVoteRequest);
         String homePostListResponseContent = Files.readString(homePostListResponse);
+        String policyResponseContent = Files.readString(policyResponse);
+        String updateProfileResponseContent = Files.readString(updateProfileResponse);
 
         assertThat(authApiContent).contains("async createUser(");
         assertThat(authApiContent).contains("async refreshAccessToken(");
         assertThat(authApiContent).contains("async logout(");
         assertThat(oauthApiContent).contains("async login(");
+        assertThat(oauthApiContent).contains("async handleOAuthCallback(");
+        assertThat(oauthApiContent).contains("async deleteUser(");
 
         assertThat(postApiContent).contains("async getHomePosts(");
         assertThat(postApiContent).contains("async getPostDetail(");
@@ -192,9 +221,26 @@ class OpenApiGenerationVerificationTest {
 
         assertThat(commentApiContent).contains("async createComment(");
         assertThat(commentApiContent).contains("async getComments(");
+        assertThat(commentApiContent).contains("async updateComment(");
+        assertThat(commentApiContent).contains("async deleteComment(");
+        assertThat(commentApiContent).contains("async createCommentHelpful(");
+        assertThat(commentApiContent).contains("async deleteCommentHelpful(");
+
+        assertThat(userApiContent).contains("async updateProfile(");
+        assertThat(userApiContent).contains("async checkNickname(");
+        assertThat(userApiContent).contains("async getMyPage(");
+        assertThat(userApiContent).contains("async getHoguReport(");
+        assertThat(userApiContent).contains("async getMyPosts(");
+        assertThat(userApiContent).contains("async getMyComments(");
+        assertThat(userApiContent).contains("async getMyBookmarks(");
+        assertThat(userApiContent).contains("async getMyVotes(");
+
+        assertThat(policyApiContent).contains("async getPrivacyPolicy(");
 
         assertThat(postVoteRequestContent).contains("Hogu: 'HOGU'");
         assertThat(postVoteRequestContent).contains("NotHogu: 'NOT_HOGU'");
         assertThat(homePostListResponseContent).contains("HomePostListResponse");
+        assertThat(policyResponseContent).contains("PolicyResponse");
+        assertThat(updateProfileResponseContent).contains("UpdateProfileResponse");
     }
 }

--- a/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/openapi/OpenApiGenerationVerificationTest.java
@@ -1,0 +1,200 @@
+package com.hogu.am_i_hogu.common.openapi;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hogu.am_i_hogu.common.config.OpenApiConfig;
+import com.hogu.am_i_hogu.common.security.JwtProvider;
+import com.hogu.am_i_hogu.domain.auth.controller.AuthController;
+import com.hogu.am_i_hogu.domain.auth.service.LogoutService;
+import com.hogu.am_i_hogu.domain.auth.service.OnboardingService;
+import com.hogu.am_i_hogu.domain.auth.service.ReissueService;
+import com.hogu.am_i_hogu.domain.comment.controller.CommentController;
+import com.hogu.am_i_hogu.domain.comment.service.CommentCreateService;
+import com.hogu.am_i_hogu.domain.comment.service.CommentDeleteService;
+import com.hogu.am_i_hogu.domain.comment.service.CommentHelpfulService;
+import com.hogu.am_i_hogu.domain.comment.service.CommentReadService;
+import com.hogu.am_i_hogu.domain.comment.service.CommentUpdateService;
+import com.hogu.am_i_hogu.domain.oauth.controller.OAuthController;
+import com.hogu.am_i_hogu.domain.oauth.service.OAuthService;
+import com.hogu.am_i_hogu.domain.oauth.service.UserDeletionService;
+import com.hogu.am_i_hogu.domain.post.controller.PostController;
+import com.hogu.am_i_hogu.domain.post.service.HomePostQueryService;
+import com.hogu.am_i_hogu.domain.post.service.PostBookmarkService;
+import com.hogu.am_i_hogu.domain.post.service.PostCreateService;
+import com.hogu.am_i_hogu.domain.post.service.PostDeleteService;
+import com.hogu.am_i_hogu.domain.post.service.PostDetailService;
+import com.hogu.am_i_hogu.domain.post.service.PostUpdateService;
+import com.hogu.am_i_hogu.domain.post.service.PostVoteService;
+import com.hogu.am_i_hogu.domain.user.controller.UserController;
+import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
+import com.hogu.am_i_hogu.domain.user.service.HoguReportService;
+import com.hogu.am_i_hogu.domain.user.service.MyBookmarkQueryService;
+import com.hogu.am_i_hogu.domain.user.service.MyCommentQueryService;
+import com.hogu.am_i_hogu.domain.user.service.MyPageService;
+import com.hogu.am_i_hogu.domain.user.service.MyPostQueryService;
+import com.hogu.am_i_hogu.domain.user.service.MyVoteQueryService;
+import com.hogu.am_i_hogu.domain.user.service.NicknameCheckService;
+import com.hogu.am_i_hogu.domain.user.service.ProfileUpdateService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+import org.springdoc.core.configuration.SpringDocSecurityConfiguration;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = {
+        PostController.class,
+        CommentController.class,
+        AuthController.class,
+        OAuthController.class,
+        UserController.class
+})
+@AutoConfigureMockMvc(addFilters = false)
+@Import({
+        OpenApiConfig.class,
+        SpringDocConfiguration.class,
+        SpringDocWebMvcConfiguration.class,
+        SpringDocSecurityConfiguration.class
+})
+@EnableConfigurationProperties({
+        OpenApiConfig.OpenApiProperties.class,
+        SpringDocConfigProperties.class,
+        SwaggerUiConfigProperties.class
+})
+@ActiveProfiles("test")
+class OpenApiGenerationVerificationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean private PostCreateService postCreateService;
+    @MockBean private PostDetailService postDetailService;
+    @MockBean private PostUpdateService postUpdateService;
+    @MockBean private PostDeleteService postDeleteService;
+    @MockBean private PostBookmarkService postBookmarkService;
+    @MockBean private PostVoteService postVoteService;
+    @MockBean private HomePostQueryService homePostQueryService;
+    @MockBean private CommentCreateService commentCreateService;
+    @MockBean private CommentReadService commentReadService;
+    @MockBean private CommentUpdateService commentUpdateService;
+    @MockBean private CommentDeleteService commentDeleteService;
+    @MockBean private CommentHelpfulService commentHelpfulService;
+    @MockBean private OnboardingService onboardingService;
+    @MockBean private ReissueService reissueService;
+    @MockBean private LogoutService logoutService;
+    @MockBean private OAuthService oauthService;
+    @MockBean private UserDeletionService userDeletionService;
+    @MockBean private JwtProvider jwtProvider;
+    @MockBean private UserRepository userRepository;
+    @MockBean private AuthenticationEntryPoint authenticationEntryPoint;
+    @MockBean private AccessDeniedHandler accessDeniedHandler;
+    @MockBean private NicknameCheckService nicknameCheckService;
+    @MockBean private ProfileUpdateService profileUpdateService;
+    @MockBean private MyPostQueryService myPostQueryService;
+    @MockBean private MyCommentQueryService myCommentQueryService;
+    @MockBean private MyBookmarkQueryService myBookmarkQueryService;
+    @MockBean private MyVoteQueryService myVoteQueryService;
+    @MockBean private MyPageService myPageService;
+    @MockBean private HoguReportService hoguReportService;
+
+    @Test
+    void apiDocs_and_typescriptFetch_generation_are_valid(@TempDir Path tempDir) throws Exception {
+        String apiDocs = mockMvc.perform(get("/v3/api-docs").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode root = objectMapper.readTree(apiDocs);
+        assertThat(root.get("openapi").asText()).startsWith("3.0");
+        assertThat(root.get("paths").get("/api/posts").get("get").get("operationId").asText()).isEqualTo("getHomePosts");
+        assertThat(root.get("paths").get("/api/posts/{postId}").get("get").get("operationId").asText()).isEqualTo("getPostDetail");
+        assertThat(root.get("paths").get("/api/posts/{postId}/comments").get("post").get("operationId").asText()).isEqualTo("createComment");
+        assertThat(root.get("paths").get("/api/auth/login/{provider}").get("get").get("operationId").asText()).isEqualTo("login");
+        assertThat(root.at("/components/securitySchemes/bearerAuth/type").asText()).isEqualTo("http");
+
+        Path specFile = tempDir.resolve("api-docs.json");
+        Files.writeString(specFile, apiDocs);
+
+        Path outputDir = tempDir.resolve("typescript-fetch");
+        Files.createDirectories(outputDir);
+
+        Process process = new ProcessBuilder(List.of(
+                "docker", "run", "--rm",
+                "-v", tempDir.toAbsolutePath() + ":/local",
+                "openapitools/openapi-generator-cli:v7.13.0",
+                "generate",
+                "-i", "/local/api-docs.json",
+                "-g", "typescript-fetch",
+                "-o", "/local/typescript-fetch"
+        )).redirectErrorStream(true).start();
+
+        String generatorOutput = new String(process.getInputStream().readAllBytes());
+        int exitCode = process.waitFor();
+        assertThat(exitCode)
+                .withFailMessage("openapi-generator failed with output:%n%s", generatorOutput)
+                .isZero();
+
+        Path authApi = outputDir.resolve("apis/AuthApi.ts");
+        Path oauthApi = outputDir.resolve("apis/OAuthApi.ts");
+        Path postApi = outputDir.resolve("apis/PostApi.ts");
+        Path commentApi = outputDir.resolve("apis/CommentApi.ts");
+        Path postVoteRequest = outputDir.resolve("models/PostVoteRequest.ts");
+        Path homePostListResponse = outputDir.resolve("models/HomePostListResponse.ts");
+
+        assertThat(authApi).exists();
+        assertThat(oauthApi).exists();
+        assertThat(postApi).exists();
+        assertThat(commentApi).exists();
+        assertThat(postVoteRequest).exists();
+        assertThat(homePostListResponse).exists();
+
+        String authApiContent = Files.readString(authApi);
+        String oauthApiContent = Files.readString(oauthApi);
+        String postApiContent = Files.readString(postApi);
+        String commentApiContent = Files.readString(commentApi);
+        String postVoteRequestContent = Files.readString(postVoteRequest);
+        String homePostListResponseContent = Files.readString(homePostListResponse);
+
+        assertThat(authApiContent).contains("async createUser(");
+        assertThat(authApiContent).contains("async refreshAccessToken(");
+        assertThat(authApiContent).contains("async logout(");
+        assertThat(oauthApiContent).contains("async login(");
+
+        assertThat(postApiContent).contains("async getHomePosts(");
+        assertThat(postApiContent).contains("async getPostDetail(");
+        assertThat(postApiContent).contains("async createPost(");
+        assertThat(postApiContent).contains("async updatePost(");
+        assertThat(postApiContent).contains("async deletePost(");
+
+        assertThat(commentApiContent).contains("async createComment(");
+        assertThat(commentApiContent).contains("async getComments(");
+
+        assertThat(postVoteRequestContent).contains("Hogu: 'HOGU'");
+        assertThat(postVoteRequestContent).contains("NotHogu: 'NOT_HOGU'");
+        assertThat(homePostListResponseContent).contains("HomePostListResponse");
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,10 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
+springdoc:
+  api-docs:
+    version: OPENAPI_3_0
+
 server:
   env: test
   port: 8080
@@ -25,6 +29,10 @@ jwt:
 app:
   cookie:
     secure: true
+  openapi:
+    title: am-i-hogu API
+    version: v1
+    server-uri: http://localhost:8080
   token-encryption:
     secret: 0SYHAlsZfTy7E4sI59brKOlP3PpK6WC8jvBdjNw8xOo=
   redirect:


### PR DESCRIPTION
## 📋 변경 사항
SpringDoc OpenAPI 관련 의존성 추가하여 API를 명세화하였습니다.
- SpringDoc OpenAPI 관련 의존성 추가
- Swagger UI 내 JWT Bearer Token 인증 기능 추가
- 주요 컨트롤러에 `@Operation`, `@ApiResponses` 등을 적용하여 성공/실패 응답 및 예시 데이터 명세 작성
- `/v3/api-docs` JSON 추출하여 검증

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [x] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

`OpenApiGenerationVerificationTest`
- `/v3/api-docs` endpoint 정상 호출 및 반환된 JSON 스펙 파일 구조 검증
- 추출된 JSON 파일을 기반으로 Docker 환경에서 `openapi-generator-cli` 정상 실행 및 종료 확인
- 생성된 ts 파일들이 지정된 디렉토리에 생성되었는지 확인
- 생성된 파일 내부의 코드가 의도한 포맷으로 정상 렌더링 되었는지 확인
```bash
./gradlew test --tests 'com.hogu.am_i_hogu.common.openapi.*'
BUILD SUCCESSFUL in 8s
```