### PR TITLE
feat: Post 등록/수정 이미지 S3 + CloudFront 연동

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
@@ -75,6 +75,18 @@ public interface ImageApiDoc {
                     )
             ),
             @ApiResponse(
+                    responseCode = "404",
+                    description = """
+                            사용자를 찾을 수 없어 실패한다. 다음 오류 코드가 발생할 수 있다:
+                            * `USER_NOT_FOUND`: 존재하지 않거나 삭제된 사용자인 경우
+                            """,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(name = "USER_NOT_FOUND", value = "{\"code\":\"USER_NOT_FOUND\"}")
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "413",
                     description = """
                             파일 크기 초과로 실패한다. 다음 오류 코드가 발생할 수 있다:

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Post", description = "게시물 API")
@@ -101,6 +102,8 @@ public interface ImageApiDoc {
             )
     })
     ResponseEntity<ImageUploadResponse> uploadImage(
+            @Parameter(hidden = true)
+            Authentication authentication,
             @Parameter(
                     description = "업로드 할 이미지 파일",
                     required = true

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
@@ -20,6 +20,7 @@ public class ImageController implements ImageApiDoc {
     private final ImageUploadService imageUploadService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Override
     public ResponseEntity<ImageUploadResponse> uploadImage(
             Authentication authentication,
             @RequestPart(value = "image", required = false) MultipartFile image

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
@@ -5,6 +5,7 @@ import com.hogu.am_i_hogu.domain.post.service.ImageUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -20,9 +21,11 @@ public class ImageController implements ImageApiDoc {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ImageUploadResponse> uploadImage(
+            Authentication authentication,
             @RequestPart(value = "image", required = false) MultipartFile image
     ) {
-        String imageUrl = imageUploadService.upload(image);
+        Long userId = Long.valueOf(authentication.getName());
+        String imageUrl = imageUploadService.upload(userId, image);
 
         return ResponseEntity.ok(new ImageUploadResponse(imageUrl));
     }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/domain/ImageAsset.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/domain/ImageAsset.java
@@ -53,4 +53,16 @@ public class ImageAsset {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    public void attachTo(Post post, boolean isThumbnail, Integer sortOrder) {
+        this.post = post;
+        this.isThumbnail = isThumbnail;
+        this.sortOrder = sortOrder;
+    }
+
+    public void detach() {
+        this.post = null;
+        this.isThumbnail = false;
+        this.sortOrder = 0;
+    }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/ImageAssetRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/ImageAssetRepository.java
@@ -1,7 +1,9 @@
 package com.hogu.am_i_hogu.domain.post.repository;
 
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,5 +11,7 @@ import java.util.List;
 @Repository
 public interface ImageAssetRepository extends JpaRepository<ImageAsset, Long> {
     List<ImageAsset> findByPost_IdOrderBySortOrderAsc(Long postId);
-    void deleteByPost_Id(Long postId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    List<ImageAsset> findAllWithLockByUrlInOrderByUrlAsc(List<String> urls);
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/PostRepository.java
@@ -4,8 +4,10 @@ import com.hogu.am_i_hogu.domain.post.domain.Post;
 import com.hogu.am_i_hogu.domain.user.dto.CategoryAnalysisSummary;
 import com.hogu.am_i_hogu.domain.user.dto.MyPostSummary;
 import com.hogu.am_i_hogu.domain.user.dto.PostVoteSummary;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,6 +20,14 @@ import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            SELECT p
+            FROM Post p
+            WHERE p.id = :postId
+            """)
+    Optional<Post> findByIdWithLock(@Param("postId") Long postId);
 
     @Transactional
     @Modifying

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
@@ -3,11 +3,17 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
+import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.exception.ImageErrorCode;
+import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
+import com.hogu.am_i_hogu.domain.user.domain.User;
+import com.hogu.am_i_hogu.domain.user.exception.UserErrorCode;
+import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.Set;
 
@@ -26,17 +32,47 @@ public class ImageUploadService {
 
     private final TsidGenerator tsidGenerator;
     private final S3StorageService s3StorageService;
+    private final UserRepository userRepository;
+    private final ImageAssetRepository imageAssetRepository;
 
-    public String upload(MultipartFile image) {
+    /**
+     * 인증 사용자의 게시물 이미지를 S3에 업로드하고, 반환된 CloudFront URL을 image_assets에 저장한다.
+     *
+     * @param userId 이미지를 업로드하는 인증 사용자 id
+     * @param image 업로드할 multipart 이미지 파일
+     * @return 업로드된 이미지에 접근할 CloudFront URL
+     * @throws CustomException 파일 검증에 실패하거나 활성 사용자 정보를 찾을 수 없는 경우
+     */
+    public String upload(Long userId, MultipartFile image) {
         validate(image);
 
+        User uploader = userRepository.findByIdAndIsDeletedFalse(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         long imageId = tsidGenerator.nextId();
         String extension = extractExtension(image.getOriginalFilename());
         String key = "images/posts/%d.%s".formatted(imageId, extension);
+        String imageUrl = s3StorageService.upload(key, image);
 
-        return s3StorageService.upload(key, image);
+        imageAssetRepository.save(ImageAsset.builder()
+                .id(imageId)
+                .uploadedByUser(uploader)
+                .url(imageUrl)
+                .contentType(image.getContentType())
+                .sizeBytes(image.getSize())
+                .isThumbnail(false)
+                .sortOrder(0)
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        return imageUrl;
     }
 
+    /**
+     * 업로드 파일의 존재 여부, 크기, MIME 타입, 확장자를 이미지 업로드 정책에 따라 검증한다.
+     *
+     * @param image 검증할 multipart 이미지 파일
+     * @throws CustomException 이미지 파일이 비었거나 크기 또는 형식 제한을 위반한 경우
+     */
     private void validate(MultipartFile image) {
         if (image == null || image.isEmpty()) {
             throw new CustomException(ImageErrorCode.EMPTY_IMAGE_FILE);
@@ -53,6 +89,12 @@ public class ImageUploadService {
         }
     }
 
+    /**
+     * 파일명에서 소문자로 정규화된 확장자를 추출한다.
+     *
+     * @param filename 확장자를 확인할 원본 파일명
+     * @return 파일명에 유효한 확장자가 있으면 소문자 확장자, 아니면 빈 문자열
+     */
     private String extractExtension(String filename) {
         if (filename == null || filename.isBlank()) {
             return "";

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostCreateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostCreateService.java
@@ -28,8 +28,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,6 +62,10 @@ public class PostCreateService {
         User writer = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         Category category = categoryRepository.findById(request.categories().get(0)).orElseThrow();
+        List<PostImageRequest> images = request.images() == null
+                ? Collections.emptyList()
+                : request.images();
+        List<ImageAsset> imageAssets = findAttachableImageAssets(userId, images);
 
         // posts.id는 TSID로 생성한다.
         Post post = Post.builder()
@@ -72,13 +79,14 @@ public class PostCreateService {
                 .build();
         Post savedPost = postRepository.save(post);
 
-        // 이미지가 전달된 경우 생성된 게시물에 연결해 image_assets에 저장한다. 빈 배열이면 저장하지 않는다.
-        List<PostImageRequest> images = request.images() == null
-                ? Collections.emptyList()
-                : request.images();
-        List<ImageAsset> imageAssets = images.stream()
-                .map(image -> createImageAsset(writer, savedPost, image, now))
-                .toList();
+        for (int index = 0; index < images.size(); index++) {
+            PostImageRequest image = images.get(index);
+            imageAssets.get(index).attachTo(
+                    savedPost,
+                    Boolean.TRUE.equals(image.isThumbnail()),
+                    image.order()
+            );
+        }
         imageAssetRepository.saveAll(imageAssets);
 
         return new PostCreateResponse(savedPost.getId());
@@ -229,48 +237,44 @@ public class PostCreateService {
     }
 
     /**
-     * 게시물 생성 요청의 이미지 정보를 image_assets 엔티티로 변환한다.
+     * 게시물에 연결할 업로드 image asset을 URL 순서로 잠금 조회한 뒤 요청 순서로 반환한다.
      *
-     * @param writer 이미지를 업로드한 사용자
-     * @param post 이미지가 연결될 게시물
-     * @param image 요청으로 전달된 이미지 정보
-     * @param now 이미지 생성 시각
-     * @return 저장할 ImageAsset 엔티티
+     * @param userId 게시물을 작성하는 인증 사용자 id
+     * @param images 게시물에 연결할 이미지 요청 목록
+     * @return 요청 목록 순서와 동일한 연결 가능 image asset 목록
+     * @throws CustomException 업로드되지 않았거나 다른 사용자 또는 다른 게시물에 속한 이미지가 포함된 경우
      */
-    private ImageAsset createImageAsset(
-            User writer,
-            Post post,
-            PostImageRequest image,
-            LocalDateTime now
-    ) {
-        return ImageAsset.builder()
-                .id(tsidGenerator.nextId())
-                .uploadedByUser(writer)
-                .post(post)
-                .url(image.imageUrl())
-                .contentType(resolveContentType(image.imageUrl()))
-                .isThumbnail(Boolean.TRUE.equals(image.isThumbnail()))
-                .sortOrder(image.order())
-                .createdAt(now)
-                .build();
-    }
-
-    /**
-     * 이미지 URL 확장자를 기준으로 저장할 MIME 타입을 추론한다.
-     *
-     * @param imageUrl 이미지 URL
-     * @return 추론한 MIME 타입
-     */
-    private String resolveContentType(String imageUrl) {
-        // POST 생성 요청에는 contentType이 없으므로 임시로 URL 확장자에서 MIME 타입을 추론한다.
-        String lowerImageUrl = imageUrl.toLowerCase(Locale.ROOT);
-        if (lowerImageUrl.endsWith(".png")) {
-            return "image/png";
-        }
-        if (lowerImageUrl.endsWith(".webp")) {
-            return "image/webp";
+    private List<ImageAsset> findAttachableImageAssets(Long userId, List<PostImageRequest> images) {
+        if (images.isEmpty()) {
+            return Collections.emptyList();
         }
 
-        return "image/jpeg";
+        List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
+        List<ImageAsset> imageAssets = new ArrayList<>();
+        List<String> sortedImageUrls = images.stream()
+                .map(PostImageRequest::imageUrl)
+                .sorted()
+                .toList();
+        Map<String, ImageAsset> imageAssetsByUrl = imageAssetRepository
+                .findAllWithLockByUrlInOrderByUrlAsc(sortedImageUrls)
+                .stream()
+                .collect(Collectors.toMap(ImageAsset::getUrl, Function.identity()));
+
+        for (PostImageRequest image : images) {
+            ImageAsset imageAsset = imageAssetsByUrl.get(image.imageUrl());
+            if (imageAsset == null
+                    || !Objects.equals(imageAsset.getUploadedByUser().getId(), userId)
+                    || imageAsset.getPost() != null) {
+                errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
+                continue;
+            }
+            imageAssets.add(imageAsset);
+        }
+
+        if (!errors.isEmpty()) {
+            throw new CustomException(PostErrorCode.INVALID_INPUT_VALUE, errors);
+        }
+
+        return imageAssets;
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
@@ -52,7 +52,7 @@ public class PostUpdateService {
         validate(request);
 
         // 삭제된 게시물인지 조회한다.
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findByIdWithLock(postId)
                 .orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 
         // 삭제된 게시물이라면 POST_ALREADY_DELETED 에러를 반환한다.

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
@@ -3,7 +3,6 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
-import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.domain.Category;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
@@ -14,7 +13,6 @@ import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
 import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
-import com.hogu.am_i_hogu.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,19 +21,31 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostUpdateService {
-    private final TsidGenerator tsidGenerator;
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
     private final ImageAssetRepository imageAssetRepository;
 
+    /**
+     * 게시물 수정 요청을 검증하고, 요청된 이미지가 있으면 업로드 image asset 연결을 교체한다.
+     *
+     * @param postId 수정할 게시물 id
+     * @param userId 수정을 요청하는 인증 사용자 id
+     * @param request 게시물 수정 요청 본문
+     * @return 수정된 게시물 id를 담은 응답 DTO
+     * @throws CustomException 요청 검증에 실패하거나 수정 권한 또는 대상 게시물 조건을 만족하지 못한 경우
+     */
     @Transactional
     public PostUpdateResponse update(Long postId, Long userId, PostUpdateRequest request) {
         // 요청 본문과 필드 유효성을 먼저 검증해 DB 변경 전에 명세의 오류 응답을 확정한다.
@@ -65,21 +75,33 @@ public class PostUpdateService {
 
         post.update(request.title(), category, request.content(), now);
 
-        // 수정된 이미지가 있다면, 해당 게시물과 연결된 이미지를 모두 지우고 덮어씌운다.
+        // 수정된 이미지가 있다면 기존 연결을 해제하고 업로드된 image asset을 요청 순서대로 다시 연결한다.
         if (request.images() != null) {
-            imageAssetRepository.deleteByPost_Id(postId);
+            List<ImageAsset> imageAssets = findAttachableImageAssets(postId, userId, request.images());
+            List<ImageAsset> previousImageAssets = imageAssetRepository.findByPost_IdOrderBySortOrderAsc(postId);
+            previousImageAssets.forEach(ImageAsset::detach);
             imageAssetRepository.flush();
 
-            List<ImageAsset> imageAssets = request.images().stream()
-                    .map(image -> createImageAsset(post.getWriter(), post, image, now))
-                    .toList();
-
+            for (int index = 0; index < request.images().size(); index++) {
+                PostImageRequest image = request.images().get(index);
+                imageAssets.get(index).attachTo(
+                        post,
+                        Boolean.TRUE.equals(image.isThumbnail()),
+                        image.order()
+                );
+            }
             imageAssetRepository.saveAll(imageAssets);
         }
 
         return new PostUpdateResponse(post.getId());
     }
 
+    /**
+     * 게시물 수정 요청 body와 전달된 필드의 유효성을 검증한다.
+     *
+     * @param request 게시물 수정 요청 본문
+     * @throws CustomException body가 없거나 전달된 필드의 유효성 검사에 실패한 경우
+     */
     private void validate(PostUpdateRequest request) {
         // body 자체가 없으면 필드별 오류보다 EMPTY_REQUEST_BODY를 우선 반환한다.
         if (request == null) {
@@ -235,48 +257,49 @@ public class PostUpdateService {
     }
 
     /**
-     * 게시물 수정 요청의 이미지 정보를 image_assets 엔티티로 변환한다.
+     * 게시물에 연결할 업로드 image asset을 URL 순서로 잠금 조회한 뒤 요청 순서로 반환한다.
      *
-     * @param writer 이미지를 업로드한 사용자
-     * @param post 이미지를 수정할 게시물
-     * @param image 요청으로 전달된 이미지 정보
-     * @param now 이미지 생성 시각
-     * @return 저장할 ImageAsset 엔티티
+     * @param postId 이미지를 수정할 게시물 id
+     * @param userId 수정을 요청하는 인증 사용자 id
+     * @param images 게시물에 연결할 이미지 요청 목록
+     * @return 요청 목록 순서와 동일한 연결 가능 image asset 목록
+     * @throws CustomException 업로드되지 않았거나 다른 사용자 또는 다른 게시물에 속한 이미지가 포함된 경우
      */
-    private ImageAsset createImageAsset(
-            User writer,
-            Post post,
-            PostImageRequest image,
-            LocalDateTime now
+    private List<ImageAsset> findAttachableImageAssets(
+            Long postId,
+            Long userId,
+            List<PostImageRequest> images
     ) {
-        return ImageAsset.builder()
-                .id(tsidGenerator.nextId())
-                .uploadedByUser(writer)
-                .post(post)
-                .url(image.imageUrl())
-                .contentType(resolveContentType(image.imageUrl()))
-                .isThumbnail(Boolean.TRUE.equals(image.isThumbnail()))
-                .sortOrder(image.order())
-                .createdAt(now)
-                .build();
-    }
-
-    /**
-     * 이미지 URL 확장자를 기준으로 저장할 MIME 타입을 추론한다.
-     *
-     * @param imageUrl 이미지 URL
-     * @return 추론한 MIME 타입
-     */
-    private String resolveContentType(String imageUrl) {
-        // 게시물 이미지 요청에는 contentType이 없으므로 임시로 URL 확장자에서 MIME 타입을 추론한다.
-        String lowerImageUrl = imageUrl.toLowerCase(Locale.ROOT);
-        if (lowerImageUrl.endsWith(".png")) {
-            return "image/png";
-        }
-        if (lowerImageUrl.endsWith(".webp")) {
-            return "image/webp";
+        if (images.isEmpty()) {
+            return Collections.emptyList();
         }
 
-        return "image/jpeg";
+        List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
+        List<ImageAsset> imageAssets = new ArrayList<>();
+        List<String> sortedImageUrls = images.stream()
+                .map(PostImageRequest::imageUrl)
+                .sorted()
+                .toList();
+        Map<String, ImageAsset> imageAssetsByUrl = imageAssetRepository
+                .findAllWithLockByUrlInOrderByUrlAsc(sortedImageUrls)
+                .stream()
+                .collect(Collectors.toMap(ImageAsset::getUrl, Function.identity()));
+
+        for (PostImageRequest image : images) {
+            ImageAsset imageAsset = imageAssetsByUrl.get(image.imageUrl());
+            if (imageAsset == null
+                    || !Objects.equals(imageAsset.getUploadedByUser().getId(), userId)
+                    || (imageAsset.getPost() != null && !Objects.equals(imageAsset.getPost().getId(), postId))) {
+                errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
+                continue;
+            }
+            imageAssets.add(imageAsset);
+        }
+
+        if (!errors.isEmpty()) {
+            throw new CustomException(PostErrorCode.INVALID_INPUT_VALUE, errors);
+        }
+
+        return imageAssets;
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostVoteService.java
@@ -48,7 +48,6 @@ public class PostVoteService {
     public PostVoteResponse cancel(Long userId, Long postId) {
         Post post = getPostOrThrow(postId);
         validateNotDeleted(post);
-        validateNotWriter(post, userId);
 
         LocalDateTime now = LocalDateTime.now();
         postVoteRepository.findById(new PostVoteId(userId, postId))

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
@@ -7,10 +7,13 @@ import com.hogu.am_i_hogu.common.security.JwtProvider;
 import com.hogu.am_i_hogu.common.security.SecurityConfig;
 import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
+import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
+import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.service.ImageUploadService;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -24,8 +27,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.Collections;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -55,15 +60,19 @@ class ImageControllerTest {
     @MockitoBean
     private S3StorageService s3StorageService;
 
+    @MockitoBean
+    private ImageAssetRepository imageAssetRepository;
+
     // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 CloudFront imageUrl을 반환한다.
     @Test
     void uploadImageReturnsS3ImageUrl() throws Exception {
+        User uploader = mock(User.class);
         when(jwtProvider.validateAccessToken("valid-token"))
                 .thenReturn(JwtProvider.TokenValidationResult.VALID);
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(mock(User.class)));
+                .thenReturn(Optional.of(uploader));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
@@ -85,6 +94,15 @@ class ImageControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.imageUrl", startsWith("https://d111111abcdef8.cloudfront.net/images/posts/")));
+
+        ArgumentCaptor<ImageAsset> imageAssetCaptor = ArgumentCaptor.forClass(ImageAsset.class);
+        verify(imageAssetRepository).save(imageAssetCaptor.capture());
+        ImageAsset imageAsset = imageAssetCaptor.getValue();
+        assertThat(imageAsset.getUploadedByUser()).isSameAs(uploader);
+        assertThat(imageAsset.getPost()).isNull();
+        assertThat(imageAsset.getUrl()).isEqualTo("https://d111111abcdef8.cloudfront.net/images/posts/1.jpg");
+        assertThat(imageAsset.getContentType()).isEqualTo(MediaType.IMAGE_JPEG_VALUE);
+        assertThat(imageAsset.getSizeBytes()).isEqualTo((long) "image-content".getBytes().length);
     }
 
     // 실패 케이스: multipart 요청에 image 파일이 없으면 400 Bad Request와 EMPTY_IMAGE_FILE을 반환한다.

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -297,6 +297,8 @@ class PostControllerTest {
     @Test
     void createPostReturnsPostIdAndPersistsPost() throws Exception {
         stubAuthenticatedUser();
+        LocalDateTime now = LocalDateTime.now();
+        insertUploadedImage(1001L, "http://localhost/temporary/images/1/post-image.jpg", now);
 
         String requestBody = """
                 {
@@ -333,6 +335,103 @@ class PostControllerTest {
                 postId
         );
         assertThat(imageCount).isEqualTo(1);
+    }
+
+    // 실패 케이스: 이미지 업로드 API로 생성되지 않은 URL은 게시물 이미지로 연결할 수 없다.
+    @Test
+    void createPostRejectsImageThatWasNotUploaded() throws Exception {
+        stubAuthenticatedUser();
+
+        String requestBody = """
+                {
+                  "title": "제목입니다",
+                  "categories": ["USED_TRADE"],
+                  "content": "본문입니다",
+                  "images": [
+                    {
+                      "imageUrl": "https://external.example.com/not-uploaded.jpg",
+                      "order": 0,
+                      "isThumbnail": true
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/posts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("images"))
+                .andExpect(jsonPath("$.errors[0].code").value("INVALID_IMAGE_URL"));
+    }
+
+    // 실패 케이스: 다른 사용자가 업로드한 이미지는 게시물 이미지로 연결할 수 없다.
+    @Test
+    void createPostRejectsImageUploadedByAnotherUser() throws Exception {
+        stubAuthenticatedUser();
+        LocalDateTime now = LocalDateTime.now();
+        Long otherUserId = 2L;
+        insertUser(otherUserId, "other-hogu", now);
+        insertUploadedImage(1001L, otherUserId, "https://cdn.example.com/another-user.jpg", now);
+
+        String requestBody = """
+                {
+                  "title": "제목입니다",
+                  "categories": ["USED_TRADE"],
+                  "content": "본문입니다",
+                  "images": [
+                    {
+                      "imageUrl": "https://cdn.example.com/another-user.jpg",
+                      "order": 0,
+                      "isThumbnail": true
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/posts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("images"))
+                .andExpect(jsonPath("$.errors[0].code").value("INVALID_IMAGE_URL"));
+    }
+
+    // 실패 케이스: 이미 다른 게시물에 연결된 이미지는 새 게시물에서 재사용할 수 없다.
+    @Test
+    void createPostRejectsImageAlreadyAttachedToPost() throws Exception {
+        stubAuthenticatedUser();
+        LocalDateTime now = LocalDateTime.now();
+        insertPost(1234L, TEST_USER_ID, "USED_TRADE", "기존 글", "기존 본문", false, now);
+        insertImage(1001L, 1234L, "https://cdn.example.com/attached.jpg", true, 0, now);
+
+        String requestBody = """
+                {
+                  "title": "새 글",
+                  "categories": ["USED_TRADE"],
+                  "content": "본문입니다",
+                  "images": [
+                    {
+                      "imageUrl": "https://cdn.example.com/attached.jpg",
+                      "order": 0,
+                      "isThumbnail": true
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/posts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("images"))
+                .andExpect(jsonPath("$.errors[0].code").value("INVALID_IMAGE_URL"));
     }
 
     // 정상 케이스: images가 빈 배열이면 이미지 없이 게시물을 생성하고 postId를 반환한다.
@@ -565,6 +664,8 @@ class PostControllerTest {
         insertPost(postId, TEST_USER_ID, "USED_TRADE", "기존 제목", "기존 본문", false, now);
         insertImage(1001L, postId, "https://example.com/old-thumbnail.jpg", true, 0, now);
         insertImage(1002L, postId, "https://example.com/old-image.jpg", false, 1, now);
+        insertUploadedImage(1003L, "https://example.com/new-thumbnail.png", now);
+        insertUploadedImage(1004L, "https://example.com/new-image.webp", now);
 
         String requestBody = """
                 {
@@ -615,6 +716,11 @@ class PostControllerTest {
                 postId,
                 "https://example.com/old-%"
         );
+        Integer detachedOldImageCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM image_assets WHERE post_id IS NULL AND url LIKE ?",
+                Integer.class,
+                "https://example.com/old-%"
+        );
         String thumbnailUrl = jdbcTemplate.queryForObject(
                 "SELECT url FROM image_assets WHERE post_id = ? AND is_thumbnail = TRUE",
                 String.class,
@@ -626,6 +732,7 @@ class PostControllerTest {
         assertThat(updatedContent).isEqualTo("수정 본문");
         assertThat(imageCount).isEqualTo(2);
         assertThat(oldImageCount).isZero();
+        assertThat(detachedOldImageCount).isEqualTo(2);
         assertThat(thumbnailUrl).isEqualTo("https://example.com/new-thumbnail.png");
     }
 
@@ -1620,6 +1727,29 @@ class PostControllerTest {
                 0L,
                 isThumbnail,
                 sortOrder,
+                now
+        );
+    }
+
+    private void insertUploadedImage(Long imageId, String imageUrl, LocalDateTime now) {
+        insertUploadedImage(imageId, TEST_USER_ID, imageUrl, now);
+    }
+
+    private void insertUploadedImage(Long imageId, Long uploadedByUserId, String imageUrl, LocalDateTime now) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO image_assets
+                    (id, uploaded_by_user_id, post_id, url, content_type, size_bytes, is_thumbnail, sort_order, created_at)
+                VALUES
+                    (?, ?, NULL, ?, ?, ?, ?, ?, ?)
+                """,
+                imageId,
+                uploadedByUserId,
+                imageUrl,
+                "image/jpeg",
+                0L,
+                false,
+                0,
                 now
         );
     }

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostCreateServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostCreateServiceTest.java
@@ -1,0 +1,96 @@
+package com.hogu.am_i_hogu.domain.post.service;
+
+import com.hogu.am_i_hogu.common.util.TsidGenerator;
+import com.hogu.am_i_hogu.domain.post.domain.Category;
+import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
+import com.hogu.am_i_hogu.domain.post.domain.Post;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostCreateRequest;
+import com.hogu.am_i_hogu.domain.post.dto.request.PostImageRequest;
+import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
+import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
+import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import com.hogu.am_i_hogu.domain.user.domain.User;
+import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PostCreateServiceTest {
+
+    private final TsidGenerator tsidGenerator = mock(TsidGenerator.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
+    private final PostRepository postRepository = mock(PostRepository.class);
+    private final ImageAssetRepository imageAssetRepository = mock(ImageAssetRepository.class);
+    private final PostCreateService postCreateService = new PostCreateService(
+            tsidGenerator,
+            userRepository,
+            categoryRepository,
+            postRepository,
+            imageAssetRepository
+    );
+
+    // 정상 케이스: 게시물 생성 시 이미지 자산은 URL 순서로 잠금 조회하고 요청 순서대로 게시물에 연결한다.
+    @Test
+    void createLocksUploadedImagesInStableOrderAndAttachesInRequestOrder() {
+        LocalDateTime now = LocalDateTime.now();
+        User writer = new User(1L, "hogu", false, now);
+        Category category = mock(Category.class);
+        ImageAsset firstByUrl = uploadedImage(101L, writer, "https://cdn.example.com/a.jpg", now);
+        ImageAsset secondByUrl = uploadedImage(102L, writer, "https://cdn.example.com/b.jpg", now);
+
+        when(categoryRepository.existsById("USED_TRADE")).thenReturn(true);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(writer));
+        when(categoryRepository.findById("USED_TRADE")).thenReturn(Optional.of(category));
+        when(tsidGenerator.nextId()).thenReturn(11L);
+        when(postRepository.save(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(imageAssetRepository.findAllWithLockByUrlInOrderByUrlAsc(List.of(
+                "https://cdn.example.com/a.jpg",
+                "https://cdn.example.com/b.jpg"
+        ))).thenReturn(List.of(firstByUrl, secondByUrl));
+
+        PostCreateRequest request = new PostCreateRequest(
+                "title",
+                List.of("USED_TRADE"),
+                "content",
+                List.of(
+                        new PostImageRequest("https://cdn.example.com/b.jpg", 0, true),
+                        new PostImageRequest("https://cdn.example.com/a.jpg", 1, false)
+                )
+        );
+
+        postCreateService.create(1L, request);
+
+        verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
+                "https://cdn.example.com/a.jpg",
+                "https://cdn.example.com/b.jpg"
+        ));
+        assertThat(secondByUrl.getPost().getId()).isEqualTo(11L);
+        assertThat(secondByUrl.isThumbnail()).isTrue();
+        assertThat(secondByUrl.getSortOrder()).isZero();
+        assertThat(firstByUrl.getPost().getId()).isEqualTo(11L);
+        assertThat(firstByUrl.isThumbnail()).isFalse();
+        assertThat(firstByUrl.getSortOrder()).isEqualTo(1);
+    }
+
+    private ImageAsset uploadedImage(Long id, User uploader, String url, LocalDateTime now) {
+        return ImageAsset.builder()
+                .id(id)
+                .uploadedByUser(uploader)
+                .url(url)
+                .contentType("image/jpeg")
+                .sizeBytes(10L)
+                .isThumbnail(false)
+                .sortOrder(0)
+                .createdAt(now)
+                .build();
+    }
+}

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
@@ -12,6 +12,7 @@ import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.when;
 
 class PostUpdateServiceTest {
@@ -130,7 +132,7 @@ class PostUpdateServiceTest {
         ImageAsset firstByUrl = uploadedImage(101L, writer, "https://cdn.example.com/a.jpg", now);
         ImageAsset secondByUrl = uploadedImage(102L, writer, "https://cdn.example.com/b.jpg", now);
 
-        when(postRepository.findById(11L)).thenReturn(Optional.of(post));
+        when(postRepository.findByIdWithLock(11L)).thenReturn(Optional.of(post));
         when(imageAssetRepository.findAllWithLockByUrlInOrderByUrlAsc(List.of(
                 "https://cdn.example.com/a.jpg",
                 "https://cdn.example.com/b.jpg"
@@ -149,7 +151,9 @@ class PostUpdateServiceTest {
 
         postUpdateService.update(11L, 1L, request);
 
-        verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
+        InOrder inOrder = inOrder(postRepository, imageAssetRepository);
+        inOrder.verify(postRepository).findByIdWithLock(11L);
+        inOrder.verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
                 "https://cdn.example.com/a.jpg",
                 "https://cdn.example.com/b.jpg"
         ));

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
@@ -1,32 +1,36 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
-import com.hogu.am_i_hogu.common.util.TsidGenerator;
+import com.hogu.am_i_hogu.domain.post.domain.Category;
+import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
+import com.hogu.am_i_hogu.domain.post.domain.Post;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostImageRequest;
 import com.hogu.am_i_hogu.domain.post.dto.request.PostUpdateRequest;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
 import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import com.hogu.am_i_hogu.domain.user.domain.User;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class PostUpdateServiceTest {
 
-    private final TsidGenerator tsidGenerator = mock(TsidGenerator.class);
     private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
     private final PostRepository postRepository = mock(PostRepository.class);
     private final ImageAssetRepository imageAssetRepository = mock(ImageAssetRepository.class);
     private final PostUpdateService postUpdateService = new PostUpdateService(
-            tsidGenerator,
             categoryRepository,
             postRepository,
             imageAssetRepository
@@ -107,5 +111,66 @@ class PostUpdateServiceTest {
         verifyNoInteractions(categoryRepository);
         verifyNoInteractions(postRepository);
         verifyNoInteractions(imageAssetRepository);
+    }
+
+    // 정상 케이스: 게시물 수정 시 이미지 자산은 URL 순서로 잠금 조회하고 요청 순서대로 다시 연결한다.
+    @Test
+    void updateLocksUploadedImagesInStableOrderAndAttachesInRequestOrder() {
+        LocalDateTime now = LocalDateTime.now();
+        User writer = new User(1L, "hogu", false, now);
+        Post post = Post.builder()
+                .id(11L)
+                .writer(writer)
+                .category(mock(Category.class))
+                .title("old title")
+                .content("old content")
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+        ImageAsset firstByUrl = uploadedImage(101L, writer, "https://cdn.example.com/a.jpg", now);
+        ImageAsset secondByUrl = uploadedImage(102L, writer, "https://cdn.example.com/b.jpg", now);
+
+        when(postRepository.findById(11L)).thenReturn(Optional.of(post));
+        when(imageAssetRepository.findAllWithLockByUrlInOrderByUrlAsc(List.of(
+                "https://cdn.example.com/a.jpg",
+                "https://cdn.example.com/b.jpg"
+        ))).thenReturn(List.of(firstByUrl, secondByUrl));
+        when(imageAssetRepository.findByPost_IdOrderBySortOrderAsc(11L)).thenReturn(List.of());
+
+        PostUpdateRequest request = new PostUpdateRequest(
+                null,
+                null,
+                null,
+                List.of(
+                        new PostImageRequest("https://cdn.example.com/b.jpg", 0, true),
+                        new PostImageRequest("https://cdn.example.com/a.jpg", 1, false)
+                )
+        );
+
+        postUpdateService.update(11L, 1L, request);
+
+        verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
+                "https://cdn.example.com/a.jpg",
+                "https://cdn.example.com/b.jpg"
+        ));
+        assertThat(secondByUrl.getPost()).isSameAs(post);
+        assertThat(secondByUrl.isThumbnail()).isTrue();
+        assertThat(secondByUrl.getSortOrder()).isZero();
+        assertThat(firstByUrl.getPost()).isSameAs(post);
+        assertThat(firstByUrl.isThumbnail()).isFalse();
+        assertThat(firstByUrl.getSortOrder()).isEqualTo(1);
+    }
+
+    private ImageAsset uploadedImage(Long id, User uploader, String url, LocalDateTime now) {
+        return ImageAsset.builder()
+                .id(id)
+                .uploadedByUser(uploader)
+                .url(url)
+                .contentType("image/jpeg")
+                .sizeBytes(10L)
+                .isThumbnail(false)
+                .sortOrder(0)
+                .createdAt(now)
+                .build();
     }
 }


### PR DESCRIPTION
## 📋 변경 사항

- `POST /api/images` 업로드 요청에서 인증 사용자 정보를 전달받아, S3 업로드 후 반환된 CloudFront URL과 업로더 정보를 `image_assets`에 저장하도록 변경했습니다.
- 게시물 생성 및 수정 시 요청으로 받은 이미지 URL을 새로 생성하지 않고, 이미지 업로드 API를 통해 미리 저장된 image asset만 연결하도록 변경했습니다.
- 다른 사용자가 업로드한 이미지, 업로드되지 않은 URL, 이미 다른 게시물에 연결된 이미지는 게시물에 연결할 수 없도록 검증을 추가했습니다.
- 게시물 이미지 교체 시 기존 image asset을 삭제하지 않고 게시물 연결만 해제하도록 변경했습니다.
- 동일한 image asset이 동시 요청으로 여러 게시물에 연결되는 문제를 방지하기 위해, URL 정렬 순서 기반의 `PESSIMISTIC_WRITE` 잠금 조회를 적용했습니다.
- 이미지 업로드, 게시물 연결/교체, 연결 불가 조건, 잠금 조회 순서를 검증하는 테스트를 추가 및 수정했습니다.

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

- `./gradlew test --rerun-tasks`
  - 결과: `BUILD SUCCESSFUL`
- 검증 범위
  - 이미지 업로드 시 CloudFront URL 및 업로더 기반 `image_assets` 저장
  - 게시물 생성 시 업로드된 이미지 연결
  - 미업로드 URL, 타 사용자 이미지, 이미 연결된 이미지 거부
  - 게시물 수정 시 기존 이미지 연결 해제 및 새 이미지 연결
  - 생성/수정 시 image asset Lock 조회 순서 및 요청 순서 연결 검증