### PR TITLE
chore: swagger 필수값 지정 및 프로필 수정 응답 형태 수정

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/common/exception/ErrorResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/exception/ErrorResponse.java
@@ -8,10 +8,10 @@ import java.util.List;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@Schema(description = "공통 에러 응답")
+@Schema(description = "공통 에러 응답", requiredProperties = {"code"})
 public class ErrorResponse {
 
-    @Schema(description = "에러 코드", example = "INVALID_PARAM_VALUE")
+    @Schema(description = "에러 코드")
     private String code;
 
     @Schema(description = "상세 에러(없을 경우 생략)", nullable = true)
@@ -41,12 +41,12 @@ public class ErrorResponse {
 
     // 상세 오류 리스트 클래스
     @Getter
-    @Schema(description = "필드별 에러 상세")
+    @Schema(description = "필드별 에러 상세", requiredProperties = {"field", "code"})
     public static class ErrorDetail {
-        @Schema(description = "에러 발생한 필드명", example = "nickname")
+        @Schema(description = "에러 발생한 필드명")
         private String field;
 
-        @Schema(description = "해당 필드의 상세 에러 코드", example = "SPECIAL_CHAR_NICKNAME")
+        @Schema(description = "해당 필드의 상세 에러 코드")
         private String code;
 
         public ErrorDetail(String field, String code) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/request/OnboardingRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/request/OnboardingRequest.java
@@ -4,14 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@Schema(name = "OnboardingRequest", description = "온보딩 요청")
+@Schema(name = "OnboardingRequest", description = "온보딩 요청", requiredProperties = {"nickname"})
 public class OnboardingRequest {
     @Schema(
             description = "사용자 닉네임. 한글, 영문, 숫자 2자~20자이며 공백 및 특수문자를 포함할 수 없다.",
-            example = "민돌이",
             minLength = 2,
-            maxLength = 20,
-            requiredMode = Schema.RequiredMode.REQUIRED
+            maxLength = 20
     )
     private final String nickname;
 

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/OnboardingResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/OnboardingResponse.java
@@ -4,12 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@Schema(name = "OnboardingResponse", description = "온보딩 응답")
+@Schema(name = "OnboardingResponse", description = "온보딩 응답", requiredProperties = {"accessToken"})
 public class OnboardingResponse {
-    @Schema(
-            description = "사용자의 access token",
-            example = "eyJhbGciOiJIUzI1NiJ9..."
-    )
+    @Schema(description = "사용자의 access token")
     private final String accessToken;
 
     public OnboardingResponse(String accessToken) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/ReissueResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/auth/dto/response/ReissueResponse.java
@@ -4,12 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
-@Schema(name = "ReissueResponse", description = "토큰 재발급 응답")
+@Schema(name = "ReissueResponse", description = "토큰 재발급 응답", requiredProperties = {"accessToken"})
 public class ReissueResponse {
-    @Schema(
-            description = "재발급된 access token",
-            example = "eyJhbGciOiJIUzI1NiJ9..."
-    )
+    @Schema(description = "재발급된 access token")
     private final String accessToken;
 
     public ReissueResponse(String accessToken) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentCreateRequest.java
@@ -4,15 +4,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(
         name = "CommentCreateRequest",
-        description = "집단지성 생성 요청. 최상위 집단지성은 parentId를 비워두고, 대댓글은 parentId에 부모 집단지성 ID를 넣는다."
+        description = "집단지성 생성 요청. 최상위 집단지성은 parentId를 비워두고, 대댓글은 parentId에 부모 집단지성 ID를 넣는다.",
+        requiredProperties = {"parentId", "content"}
 )
 public record CommentCreateRequest(
-        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true, example = "12")
-        Long parentId,
         @Schema(
-                description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.",
-                example = "호구같아요."
+                description = "부모 집단지성 ID. 최상위 집단지성인 경우 null",
+                nullable = true
         )
+        Long parentId,
+        @Schema(description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.")
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/request/CommentUpdateRequest.java
@@ -2,12 +2,9 @@ package com.hogu.am_i_hogu.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentUpdateRequest", description = "집단지성 수정 요청")
+@Schema(name = "CommentUpdateRequest", description = "집단지성 수정 요청", requiredProperties = {"content"})
 public record CommentUpdateRequest(
-        @Schema(
-                description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.",
-                example = "호구같아요."
-        )
+        @Schema(description = "집단지성 내용. 공백만 허용되지 않으며 최대 300자까지 입력할 수 있다.")
         String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentCreateResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentCreateResponse", description = "집단지성 생성 응답")
+@Schema(
+        name = "CommentCreateResponse",
+        description = "집단지성 생성 응답",
+        requiredProperties = {"commentId", "content", "isMine", "writer", "createdAt", "updatedAt", "isHelpful", "totalHelpfulCount", "parentId", "depth"}
+)
 public record CommentCreateResponse(
         @Schema(description = "집단지성 ID")
         Long commentId,
@@ -22,7 +26,7 @@ public record CommentCreateResponse(
         boolean isHelpful,
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,
-        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true, example = "12")
+        @Schema(description = "부모 집단지성 ID. 최상위 집단지성인 경우 null", nullable = true)
         Long parentId,
         @Schema(description = "집단지성 깊이. 최상위는 0, 대댓글은 1")
         int depth

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentHelpfulResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentHelpfulResponse", description = "집단지성 유익해요 응답")
+@Schema(
+        name = "CommentHelpfulResponse",
+        description = "집단지성 유익해요 응답",
+        requiredProperties = {"totalHelpfulCount", "isHelpful"}
+)
 public record CommentHelpfulResponse(
         @Schema(description = "총 유익해요 수")
         long totalHelpfulCount,

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentItemResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentItemResponse", description = "집단지성 항목")
+@Schema(
+        name = "CommentItemResponse",
+        description = "집단지성 항목",
+        requiredProperties = {"commentId", "content", "isMine", "writer", "createdAt", "updatedAt", "isDeleted", "isHelpful", "totalHelpfulCount", "parentId", "depth"}
+)
 public record CommentItemResponse(
         @Schema(description = "집단지성 ID")
         Long commentId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentReadResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "CommentReadResponse", description = "집단지성 목록 응답")
+@Schema(
+        name = "CommentReadResponse",
+        description = "집단지성 목록 응답",
+        requiredProperties = {"comments", "hasNext", "nextCursor"}
+)
 public record CommentReadResponse(
         @ArraySchema(arraySchema = @Schema(description = "집단지성 목록"))
         List<CommentItemResponse> comments,

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentUpdateResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "CommentUpdateResponse", description = "집단지성 수정 응답")
+@Schema(
+        name = "CommentUpdateResponse",
+        description = "집단지성 수정 응답",
+        requiredProperties = {"commentId", "content", "isMine", "writer", "createdAt", "updatedAt", "isHelpful", "totalHelpfulCount", "parentId", "depth"}
+)
 public record CommentUpdateResponse(
         @Schema(description = "집단지성 ID")
         Long commentId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/comment/dto/response/CommentWriterResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.comment.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CommentWriterResponse", description = "집단지성 작성자 정보")
+@Schema(
+        name = "CommentWriterResponse",
+        description = "집단지성 작성자 정보",
+        requiredProperties = {"nickname", "profileImageUrl", "isPostWriter"}
+)
 public record CommentWriterResponse(
         @Schema(description = "작성자 닉네임")
         String nickname,

--- a/src/main/java/com/hogu/am_i_hogu/domain/policy/dto/response/PolicyResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/policy/dto/response/PolicyResponse.java
@@ -4,15 +4,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "PolicyResponse", description = "현재 적용 중인 개인정보 처리 방침 응답")
+@Schema(
+        name = "PolicyResponse",
+        description = "현재 적용 중인 개인정보 처리 방침 응답",
+        requiredProperties = {"version", "updatedAt", "content"}
+)
 public record PolicyResponse(
-    @Schema(description = "정책 버전", example = "v1.0.0")
+    @Schema(description = "정책 버전")
     String version,
 
     @Schema(description = "정책 최종 수정 시각")
     LocalDateTime updatedAt,
 
-    @Schema(description = "정책 HTML 본문", example = "<h1>개인정보 처리 방침</h1>...")
+    @Schema(description = "정책 HTML 본문")
     String content
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -118,8 +119,12 @@ public interface ImageApiDoc {
             Authentication authentication,
             @Parameter(
                     description = "업로드 할 이미지 파일",
-                    required = true
+                    content = @Content(
+                            mediaType = "multipart/form-data",
+                            schema = @Schema(type = "string", format = "binary")
+                    )
             )
+            @RequestBody(required = true)
             MultipartFile image
     );
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostCreateRequest.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "PostCreateRequest", description = "게시물 생성 요청")
+@Schema(
+        name = "PostCreateRequest",
+        description = "게시물 생성 요청",
+        requiredProperties = {"title", "categories", "content", "images"}
+)
 public record PostCreateRequest(
         @Schema(description = "게시물 제목")
         String title,
@@ -13,9 +17,7 @@ public record PostCreateRequest(
         @ArraySchema(
                 minItems = 1,
                 maxItems = 1,
-                arraySchema = @Schema(description = "카테고리 코드 목록. 1개만 허용",
-                requiredMode = Schema.RequiredMode.REQUIRED
-                ),
+                arraySchema = @Schema(description = "카테고리 코드 목록. 1개만 허용"),
                 schema = @Schema(
                         type = "string",
                         allowableValues = {"USED_TRADE", "WORK", "PURCHASE", "CONTRACT", "DATING", "ETC"}

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostImageRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostImageRequest.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.post.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostImageRequest", description = "게시물 이미지 요청")
+@Schema(
+        name = "PostImageRequest",
+        description = "게시물 이미지 요청",
+        requiredProperties = {"imageUrl", "order", "isThumbnail"}
+)
 public record PostImageRequest(
         @Schema(description = "이미지 URL")
         String imageUrl,

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/request/PostVoteRequest.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.post.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostVoteRequest", description = "게시물 투표 요청")
+@Schema(
+        name = "PostVoteRequest",
+        description = "게시물 투표 요청",
+        requiredProperties = {"myVote"}
+)
 public record PostVoteRequest(
         @Schema(description = "투표 값", allowableValues = {"HOGU", "NOT_HOGU"})
         String myVote

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostItemResponse.java
@@ -6,7 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Schema(name = "HomePostItemResponse", description = "홈 게시물 요약")
+@Schema(
+        name = "HomePostItemResponse",
+        description = "홈 게시물 요약",
+        requiredProperties = {"postId", "isBookmarked", "categories", "title", "createdAt", "viewCount", "contentPreview", "thumbnailUrl", "totalVoteCount", "commentCount", "writer"}
+)
 public record HomePostItemResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/HomePostListResponse.java
@@ -6,7 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "HomePostListResponse", description = "홈 게시물 목록 응답")
+@Schema(
+        name = "HomePostListResponse",
+        description = "홈 게시물 목록 응답",
+        requiredProperties = {"posts", "hasNext", "nextCursor"}
+)
 public record HomePostListResponse(
         @Schema(description = "총 게시물 수", nullable = true)
         @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/ImageUploadResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/ImageUploadResponse.java
@@ -1,4 +1,14 @@
 package com.hogu.am_i_hogu.domain.post.dto.response;
 
-public record ImageUploadResponse(String imageUrl) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(
+        name = "ImageUploadResponse",
+        description = "이미지 업로드 응답",
+        requiredProperties = {"imageUrl"}
+)
+public record ImageUploadResponse(
+        @Schema(description = "이미지가 저장된 url")
+        String imageUrl
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostBookmarkResponse.java
@@ -2,6 +2,13 @@ package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostBookmarkResponse", description = "게시물 북마크 응답")
-public record PostBookmarkResponse(boolean isBookmarked) {
+@Schema(
+        name = "PostBookmarkResponse",
+        description = "게시물 북마크 응답",
+        requiredProperties = {"isBookmarked"}
+)
+public record PostBookmarkResponse(
+        @Schema(description = "북마크 등록 여부")
+        boolean isBookmarked
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostCreateResponse.java
@@ -2,6 +2,13 @@ package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostCreateResponse", description = "게시물 생성 응답")
-public record PostCreateResponse(Long postId) {
+@Schema(
+        name = "PostCreateResponse",
+        description = "게시물 생성 응답",
+        requiredProperties = {"postId"}
+)
+public record PostCreateResponse(
+        @Schema(description = "생성된 게시물 식별자")
+        Long postId
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
@@ -6,7 +6,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Schema(name = "PostDetailResponse", description = "게시물 상세 응답")
+@Schema(
+        name = "PostDetailResponse",
+        description = "게시물 상세 응답",
+        requiredProperties = {"postId", "isMine", "categories", "title", "createdAt", "updatedAt", "viewCount", "content", "images", "vote", "writer"}
+)
 public record PostDetailResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostUpdateResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostUpdateResponse.java
@@ -2,6 +2,13 @@ package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostUpdateResponse", description = "게시물 수정 응답")
-public record PostUpdateResponse(Long postId) {
+@Schema(
+        name = "PostUpdateResponse",
+        description = "게시물 수정 응답",
+        requiredProperties = {"postId"}
+)
+public record PostUpdateResponse(
+        @Schema(description = "수정된 게시물 식별자")
+        Long postId
+) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostVoteResponse", description = "게시물 투표 응답")
+@Schema(
+        name = "PostVoteResponse",
+        description = "게시물 투표 응답",
+        requiredProperties = {"totalVotes", "yesVotes", "noVotes", "myVote"}
+)
 public record PostVoteResponse(
         @Schema(description = "총 투표 수")
         Integer totalVotes,

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostVoteResponse.java
@@ -19,8 +19,7 @@ public record PostVoteResponse(
 
         @Schema(
                 description = "내 투표 값",
-                allowableValues = {"HOGU", "NOT_HOGU", "NONE"},
-                nullable = true
+                allowableValues = {"HOGU", "NOT_HOGU", "NONE"}
         )
         String myVote
 ) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostWriterResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostWriterResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.post.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "PostWriterResponse", description = "게시물 작성자 정보")
+@Schema(
+        name = "PostWriterResponse",
+        description = "게시물 작성자 정보",
+        requiredProperties = {"nickname", "profileImageUrl"}
+)
 public record PostWriterResponse(
         @Schema(description = "닉네임")
         String nickname,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/request/UpdateProfileRequest.java
@@ -3,12 +3,19 @@ package com.hogu.am_i_hogu.domain.user.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.openapitools.jackson.nullable.JsonNullable;
 
-@Schema(name = "UpdateProfileRequest", description = "프로필 수정 요청. 최소 1개 이상의 필드는 반드시 포함되어야 한다.")
+@Schema(
+        name = "UpdateProfileRequest",
+        description = "프로필 수정 요청. 최소 1개 이상의 필드는 반드시 포함되어야 한다."
+)
 public record UpdateProfileRequest (
         @Schema(description = "설정하고자 하는 닉네임", nullable = true)
         String nickname,
 
-        @Schema(description = "설정하고자 하는 프로필 이미지 URL. null이면 삭제 의미, 필드 미포함 시 이미지 유지 의미", nullable = true)
+        @Schema(
+                type = "string",
+                nullable = true,
+                description = "프로필 이미지 URL. 필드 미포함 시 유지, null이면 삭제, 문자열이면 업데이트"
+        )
         JsonNullable<String> profileImageUrl
 ) {
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CategoryAnalysisResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CategoryAnalysisResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CategoryAnalysisResponse", description = "카테고리별 호구 분석 응답")
+@Schema(
+        name = "CategoryAnalysisResponse",
+        description = "카테고리별 호구 분석 응답",
+        requiredProperties = {"category", "hoguIndex", "hoguLevel"}
+)
 public record CategoryAnalysisResponse(
         @Schema(
                 description = "카테고리 코드",

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CheckNicknameResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/CheckNicknameResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CheckNicknameResponse", description = "닉네임 중복 검사 응답")
+@Schema(
+        name = "CheckNicknameResponse",
+        description = "닉네임 중복 검사 응답",
+        requiredProperties = {"isAvailable"}
+)
 public record CheckNicknameResponse(
         @Schema(description = "닉네임 사용 가능 여부")
         boolean isAvailable

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/HoguReportResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/HoguReportResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "HoguReportResponse", description = "호구 보고서 응답")
+@Schema(
+        name = "HoguReportResponse",
+        description = "호구 보고서 응답",
+        requiredProperties = {"nickname", "profileImageUrl", "hoguIndex", "hoguLevel", "hoguShortDescription", "hoguDescription", "categoryAnalysis", "totalPostCount", "hoguPostCount", "notHoguPostCount"}
+)
 public record HoguReportResponse(
         @Schema(description = "닉네임")
         String nickname,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkItemResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "MyBookmarkItemResponse", description = "내 북마크 게시물 항목")
+@Schema(
+        name = "MyBookmarkItemResponse",
+        description = "내 북마크 게시물 항목",
+        requiredProperties = {"postId", "title", "category", "createdAt", "voteSummary", "commentCount", "isDeleted"}
+)
 public record MyBookmarkItemResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyBookmarkListResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "MyBookmarkListResponse", description = "내 북마크 게시물 목록 응답")
+@Schema(
+        name = "MyBookmarkListResponse",
+        description = "내 북마크 게시물 목록 응답",
+        requiredProperties = {"posts", "hasNext", "nextCursor"}
+)
 public record MyBookmarkListResponse(
         @ArraySchema(arraySchema = @Schema(description = "북마크 게시물 목록"))
         List<MyBookmarkItemResponse> posts,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentItemResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "MyCommentItemResponse", description = "내 댓글 항목")
+@Schema(
+        name = "MyCommentItemResponse",
+        description = "내 댓글 항목",
+        requiredProperties = {"commentId", "content", "createdAt", "post"}
+)
 public record MyCommentItemResponse(
         @Schema(description = "댓글 ID")
         Long commentId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentListResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "MyCommentListResponse", description = "내 댓글 목록 응답")
+@Schema(
+        name = "MyCommentListResponse",
+        description = "내 댓글 목록 응답",
+        requiredProperties = {"comments", "hasNext", "nextCursor"}
+)
 public record MyCommentListResponse(
         @ArraySchema(arraySchema = @Schema(description = "댓글 목록"))
         List<MyCommentItemResponse> comments,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentPostResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyCommentPostResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "MyCommentPostResponse", description = "내 댓글 대상 게시물 정보")
+@Schema(
+        name = "MyCommentPostResponse",
+        description = "내 댓글 대상 게시물 정보",
+        requiredProperties = {"postId", "title", "category", "commentCount", "isDeleted"}
+)
 public record MyCommentPostResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPageResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPageResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "MyPageResponse", description = "마이페이지 응답")
+@Schema(
+        name = "MyPageResponse",
+        description = "마이페이지 응답",
+        requiredProperties = {"nickname", "profileImageUrl", "hoguIndex", "hoguLevel", "hoguShortDescription"}
+)
 public record MyPageResponse(
         @Schema(description = "닉네임")
         String nickname,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostItemResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "MyPostItemResponse", description = "내 게시물 항목")
+@Schema(
+        name = "MyPostItemResponse",
+        description = "내 게시물 항목",
+        requiredProperties = {"postId", "title", "category", "createdAt", "voteSummary", "commentCount"}
+)
 public record MyPostItemResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyPostListResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "MyPostListResponse", description = "내 게시물 목록 응답")
+@Schema(
+        name = "MyPostListResponse",
+        description = "내 게시물 목록 응답",
+        requiredProperties = {"posts", "hasNext", "nextCursor"}
+)
 public record MyPostListResponse(
     @ArraySchema(arraySchema = @Schema(description = "게시물 목록"))
     List<MyPostItemResponse> posts,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteItemResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteItemResponse.java
@@ -4,7 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 
-@Schema(name = "MyVoteItemResponse", description = "내 투표 항목")
+@Schema(
+        name = "MyVoteItemResponse",
+        description = "내 투표 항목",
+        requiredProperties = {"myVote", "createdAt", "post"}
+)
 public record MyVoteItemResponse(
         @Schema(
                 description = "내 투표 값",

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteListResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVoteListResponse.java
@@ -5,7 +5,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
-@Schema(name = "MyVoteListResponse", description = "내 투표 목록 응답")
+@Schema(
+        name = "MyVoteListResponse",
+        description = "내 투표 목록 응답",
+        requiredProperties = {"votes", "hasNext", "nextCursor"}
+)
 public record MyVoteListResponse(
         @ArraySchema(arraySchema = @Schema(description = "투표 목록"))
         List<MyVoteItemResponse> votes,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVotePostResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/MyVotePostResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "MyVotePostResponse", description = "내 투표 대상 게시물 정보")
+@Schema(
+        name = "MyVotePostResponse",
+        description = "내 투표 대상 게시물 정보",
+        requiredProperties = {"postId", "title", "category", "commentCount", "isDeleted"}
+)
 public record MyVotePostResponse(
         @Schema(description = "게시물 ID")
         Long postId,

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/UpdateProfileResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/dto/response/UpdateProfileResponse.java
@@ -2,7 +2,11 @@ package com.hogu.am_i_hogu.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "UpdateProfileResponse", description = "프로필 수정 응답")
+@Schema(
+        name = "UpdateProfileResponse",
+        description = "프로필 수정 응답",
+        requiredProperties = {"id", "nickname", "profileImageUrl"}
+)
 public record UpdateProfileResponse (
         @Schema(description = "유저를 구분하는 고유의 id")
         Long id,


### PR DESCRIPTION
## 📋 변경 사항

기존 명세에 누락되어 있었던 필수값 지정을 추가하였습니다.
프로필 수정 응답의 `profileImagrUrl`이 JsonNullable 타입이 아닌 String 타입으로 보이도록 수정하였습니다.

## 🏷️ PR 유형

- [ ] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [x] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

```bash
./gradlew test --tests 'com.hogu.am_i_hogu.common.openapi.*'
BUILD SUCCESSFUL in 6s
```
