### PR TITLE
fix: OAuth redirect uri 수정

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,4 +1,7 @@
+DB_HOST=db_host
 DB_NAME=db_name
+DB_port=db_port
+DB_USER=db_user
 DB_ROOT_PASSWORD=mysql_root_password
 JWT_SECRET=base64_encoded_jwt_secret
 
@@ -10,8 +13,12 @@ KAKAO_CLIENT_SECRET=kakao_client_secret
 
 TOKEN_ENCRYPTION_SECRET=base64_encoded_token_encryption_secret
 
+API_SERVER_URL=https://api.example.com
+FRONTEND_URL=https://frontend.example.com
+
 AWS_REGION=ap-northeast-2
-AWS_S3_BUCKET=am-i-hogu-images-847041280547-ap-northeast-2-an
+AWS_S3_BUCKET=example-ap-northeast-2-an
 AWS_CLOUDFRONT_DOMAIN=https://dxxxxxxxxxxxxx.cloudfront.net
+AWS_S3_PUBLIC_BASE_URL=https://example.s3.ap-northeast-2.amazonaws.com
 AWS_ACCESS_KEY_ID=aws_access_key_id
 AWS_SECRET_ACCESS_KEY=aws_secret_access_key

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -1,17 +1,17 @@
 spring:
   datasource:
     # Docker Compose 배포 시 MySQL 서비스명(db)으로 연결
-    url: jdbc:mysql://${DB_HOST:db}:${DB_PORT:3306}/${DB_NAME:hogu_db}?useUnicode=true&serverTimezone=Asia/Seoul
-    username: ${DB_USER:root}
+가    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&serverTimezone=Asia/Seoul
+    username: ${DB_USER}
 
 oauth:
   # google 소셜 로그인 정보
   google:
-    redirect-uri: http://43.201.237.252/api/auth/callback/GOOGLE
+    redirect-uri: ${API_SERVER_URL}/api/auth/callback/GOOGLE
 
   # kakao 소셜 로그인 정보
   kakao:
-    redirect-uri: http://43.201.237.252/api/auth/callback/KAKAO
+    redirect-uri: ${API_SERVER_URL}/api/auth/callback/KAKAO
 
 server:
   env: blue
@@ -22,9 +22,8 @@ serverName: blue_server
 
 app:
   openapi:
-    server-uri: http://43.201.237.252
+    server-uri: ${API_SERVER_URL}
   redirect:
-    # 프론트 배포 전 임시값. 프론트 배포 후 FRONTEND_URL을 실제 주소로 설정한다.
-    onboarding-uri: ${FRONTEND_URL:http://localhost:3000}/onboarding
-    login-success-uri: ${FRONTEND_URL:http://localhost:3000}/oauth/callback?status=LOGIN_SUCCESS
-    login-failure-uri: ${FRONTEND_URL:http://localhost:3000}/oauth/callback?status=LOGIN_FAILED
+    onboarding-uri: ${FRONTEND_URL}/onboarding
+    login-success-uri: ${FRONTEND_URL}/oauth/callback?status=LOGIN_SUCCESS
+    login-failure-uri: ${FRONTEND_URL}/oauth/callback?status=LOGIN_FAILED

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     # Docker Compose 배포 시 MySQL 서비스명(db)으로 연결
-가    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&serverTimezone=Asia/Seoul
     username: ${DB_USER}
 
 oauth:

--- a/src/main/resources/application-common.yml
+++ b/src/main/resources/application-common.yml
@@ -56,6 +56,7 @@ oauth:
   # google 소셜 로그인 정보
   google:
     client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: http://localhost:8080/api/auth/callback/GOOGLE
     authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
     token-uri: https://oauth2.googleapis.com/token
@@ -72,6 +73,7 @@ oauth:
   # kakao 소셜 로그인 정보
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
     redirect-uri: http://localhost:8080/api/auth/callback/KAKAO
     authorization-uri: https://kauth.kakao.com/oauth/authorize
     token-uri: https://kauth.kakao.com/oauth/token

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -1,17 +1,17 @@
 spring:
   datasource:
     # Docker Compose 배포 시 MySQL 서비스명(db)으로 연결
-    url: jdbc:mysql://${DB_HOST:db}:${DB_PORT:3306}/${DB_NAME:hogu_db}?useUnicode=true&serverTimezone=Asia/Seoul
-    username: ${DB_USER:root}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useUnicode=true&serverTimezone=Asia/Seoul
+    username: ${DB_USER}
 
 oauth:
   # google 소셜 로그인 정보
   google:
-    redirect-uri: http://43.201.237.252/api/auth/callback/GOOGLE
+    redirect-uri: ${API_SERVER_URL}/api/auth/callback/GOOGLE
 
   # kakao 소셜 로그인 정보
   kakao:
-    redirect-uri: http://43.201.237.252/api/auth/callback/KAKAO
+    redirect-uri: ${API_SERVER_URL}/api/auth/callback/KAKAO
 
 server:
   env: green
@@ -22,9 +22,8 @@ serverName: green_server
 
 app:
   openapi:
-    server-uri: http://43.201.237.252
+    server-uri: ${API_SERVER_URL}
   redirect:
-    # 프론트 배포 전 임시값. 프론트 배포 후 FRONTEND_URL을 실제 주소로 설정한다.
-    onboarding-uri: ${FRONTEND_URL:http://localhost:3000}/onboarding
-    login-success-uri: ${FRONTEND_URL:http://localhost:3000}/oauth/callback?status=LOGIN_SUCCESS
-    login-failure-uri: ${FRONTEND_URL:http://localhost:3000}/oauth/callback?status=LOGIN_FAILED
+    onboarding-uri: ${FRONTEND_URL}/onboarding
+    login-success-uri: ${FRONTEND_URL}/oauth/callback?status=LOGIN_SUCCESS
+    login-failure-uri: ${FRONTEND_URL}/oauth/callback?status=LOGIN_FAILED

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,7 @@
 spring:
   datasource:
     # 로컬 MySQL 연결 설정
-    url: jdbc:mysql://localhost:3306/${DB_NAME:hogu_db}?useUnicode=true&serverTimezone=Asia/Seoul
+    url: jdbc:mysql://localhost:3306/${DB_NAME}?useUnicode=true&serverTimezone=Asia/Seoul
     username: root
 
 oauth:
@@ -26,7 +26,7 @@ app:
   openapi:
     server-uri: http://localhost:8080
   redirect:
-    # local test를 위한 uri이기 때문에 port를 8080으로 설정
-    onboarding-uri: http://localhost:8080/api/users
-    login-success-uri: http://localhost:8080/api/auth/refresh
+    # local test를 위한 uri이기 때문에 port를 3000으로 설정
+    onboarding-uri: http://localhost:3000/onboarding
+    login-success-uri: http://localhost:3000/oauth/callback?status=LOGIN_SUCCESS
     login-failure-uri: http://localhost:3000/oauth/callback?status=LOGIN_FAILED


### PR DESCRIPTION
## 📋 변경 사항

<!-- 무엇을 왜 변경했는지 간단히 설명해주세요 -->

- 배포 환경의 OAuth callback URI, OpenAPI server URI, 프론트 리다이렉트 URI를 하드코딩된 임시 IP/localhost 값 대신 환경변수 기반으로 변경했습니다.
- blue/green 프로필에서 `API_SERVER_URL`, `FRONTEND_URL`을 사용하도록 수정해 배포 도메인과 프론트 도메인을 환경별로 분리해 관리할 수 있게 했습니다.
- Google/Kakao OAuth 토큰 교환에 필요한 `client-secret` 설정을 `application-common.yml`에 추가했습니다.
- 로컬 프로필의 로그인/온보딩 리다이렉트 주소를 로컬 프론트 개발 서버(`localhost:3000`) 기준으로 수정했습니다.
- `.env` 예시 파일에 배포/DB/S3 관련 환경변수 예시를 추가하고 실제 리소스명이 노출되지 않도록 예시값으로 정리했습니다.

## 🏷️ PR 유형

- [ ] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [x] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [ ] 로컬 테스트 완료
- [x] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료