### PR TITLE
feat: 게시물 상세 응답에 북마크 여부 추가

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/dto/response/PostDetailResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Schema(
         name = "PostDetailResponse",
         description = "게시물 상세 응답",
-        requiredProperties = {"postId", "isMine", "categories", "title", "createdAt", "updatedAt", "viewCount", "content", "images", "vote", "writer"}
+        requiredProperties = {"postId", "isMine", "isBookmarked", "categories", "title", "createdAt", "updatedAt", "viewCount", "content", "images", "vote", "writer"}
 )
 public record PostDetailResponse(
         @Schema(description = "게시물 ID")
@@ -17,6 +17,9 @@ public record PostDetailResponse(
 
         @Schema(description = "내가 작성한 글 여부")
         Boolean isMine,
+
+        @Schema(description = "북마크 여부")
+        boolean isBookmarked,
 
         @ArraySchema(
                 arraySchema = @Schema(description = "카테고리 코드 목록"),

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDetailService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostDetailService.java
@@ -3,6 +3,7 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
+import com.hogu.am_i_hogu.domain.post.domain.PostBookmarkId;
 import com.hogu.am_i_hogu.domain.post.domain.PostVote;
 import com.hogu.am_i_hogu.domain.post.dto.PostVoteCounts;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostDetailResponse;
@@ -10,6 +11,7 @@ import com.hogu.am_i_hogu.domain.post.dto.response.PostVoteResponse;
 import com.hogu.am_i_hogu.domain.post.dto.response.PostWriterResponse;
 import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
+import com.hogu.am_i_hogu.domain.post.repository.PostBookmarkRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostVoteRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class PostDetailService {
 
     private final PostRepository postRepository;
     private final ImageAssetRepository imageAssetRepository;
+    private final PostBookmarkRepository postBookmarkRepository;
     private final PostVoteRepository postVoteRepository;
 
     /**
@@ -45,9 +48,10 @@ public class PostDetailService {
 
         List<String> imageUrls = getImageUrls(postId);
         boolean isMine = isMine(post, viewerUserId);
+        boolean isBookmarked = isBookmarked(postId, viewerUserId);
         PostVoteResponse vote = getVoteResponse(postId, viewerUserId);
 
-        return getPostDetailResponse(post, imageUrls, isMine, viewCount, vote);
+        return getPostDetailResponse(post, imageUrls, isMine, isBookmarked, viewCount, vote);
     }
 
     /**
@@ -127,24 +131,32 @@ public class PostDetailService {
         return viewerUserId != null && post.getWriter().getId().equals(viewerUserId);
     }
 
+    private boolean isBookmarked(Long postId, Long viewerUserId) {
+        return viewerUserId != null
+                && postBookmarkRepository.existsById(new PostBookmarkId(viewerUserId, postId));
+    }
+
     /**
      * 게시글 엔티티와 부가 조회 정보를 게시글 상세 응답 DTO로 변환한다.
      *
      * @param post 조회한 게시글
      * @param imageUrls 게시글 이미지 URL 목록
      * @param isMine 현재 조회자가 작성자인지 여부
+     * @param isBookmarked 현재 조회자의 북마크 여부
      * @return 게시글 상세 응답
      */
     private PostDetailResponse getPostDetailResponse(
             Post post,
             List<String> imageUrls,
             boolean isMine,
+            boolean isBookmarked,
             int viewCount,
             PostVoteResponse vote
     ) {
         return new PostDetailResponse(
                 post.getId(),
                 isMine,
+                isBookmarked,
                 List.of(post.getCategory().getCode()),
                 post.getTitle(),
                 post.getCreatedAt(),

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -1019,6 +1019,7 @@ class PostControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.postId").value(postId))
                 .andExpect(jsonPath("$.isMine").value(false))
+                .andExpect(jsonPath("$.isBookmarked").value(false))
                 .andExpect(jsonPath("$.categories[0]").value("USED_TRADE"))
                 .andExpect(jsonPath("$.title").value("안녕하세요"))
                 .andExpect(jsonPath("$.createdAt").exists())
@@ -1137,7 +1138,26 @@ class PostControllerTest {
                         .header("Authorization", "Bearer valid-token"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.postId").value(postId))
-                .andExpect(jsonPath("$.isMine").value(true));
+                .andExpect(jsonPath("$.isMine").value(true))
+                .andExpect(jsonPath("$.isBookmarked").value(false));
+    }
+
+    // 정상 케이스: 로그인 사용자가 북마크한 게시글을 상세 조회하면 `isBookmarked`를 `true`로 반환한다.
+    @Test
+    void getPostDetailAsAuthenticatedUserReturnsBookmarkStatus() throws Exception {
+        Long postId = 1234L;
+        Long writerUserId = 2L;
+        LocalDateTime now = LocalDateTime.now();
+
+        insertUser(writerUserId, "writer", now);
+        insertPost(postId, writerUserId, "USED_TRADE", "북마크한 글", "본문입니다", false, now);
+        insertPostBookmark(TEST_USER_ID, postId, now);
+        stubAuthenticatedUser();
+
+        mockMvc.perform(get("/api/posts/{postId}", postId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isBookmarked").value(true));
     }
 
     // 정상 케이스: 로그인 사용자가 상세 조회하면 투표 집계와 내가 선택한 투표 값을 반환한다.


### PR DESCRIPTION
## 📋 변경 사항

게시물 상세 조회 API(`GET /api/posts/{postId}`) 응답에 `isBookmarked` 필드를 추가했습니다.

- 로그인 사용자가 게시물을 북마크한 경우 `true` 반환
- 로그인했지만 북마크하지 않은 경우 `false` 반환
- 비회원인 경우 `false` 반환
- 기존 `PostBookmarkRepository.existsById`를 사용해 북마크 여부 조회
- OpenAPI 필수 응답 필드에 `isBookmarked` 반영
- 로그인 및 비회원 응답 테스트 추가

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 📝 docs: 문서 수정
- [ ] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료

## 📸 테스트 결과

```text
./gradlew test

BUILD SUCCESSFUL
tests=279 failures=0 errors=0 skipped=0
```

## 🔗 관련 이슈
- Closes #60