### PR TITLE
refactor: image upload 흐름 리팩터링

### DIFF
--- a/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
+++ b/src/main/java/com/hogu/am_i_hogu/common/storage/S3StorageService.java
@@ -1,6 +1,8 @@
 package com.hogu.am_i_hogu.common.storage;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
@@ -10,6 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 @Service
 public class S3StorageService {
@@ -41,10 +44,50 @@ public class S3StorageService {
         }
     }
 
+    public Optional<ImageMetadata> findImageMetadata(String imageUrl) {
+        return extractKey(imageUrl).flatMap(key -> {
+            try {
+                ObjectMetadata metadata = amazonS3.getObjectMetadata(bucket, key);
+                return Optional.of(new ImageMetadata(metadata.getContentType(), metadata.getContentLength()));
+            } catch (AmazonS3Exception e) {
+                if (e.getStatusCode() == 404) {
+                    return Optional.empty();
+                }
+                throw new CustomException(CommonErrorCode.SERVER_ERROR);
+            } catch (SdkClientException e) {
+                throw new CustomException(CommonErrorCode.SERVER_ERROR);
+            }
+        });
+    }
+
+    private Optional<String> extractKey(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return Optional.empty();
+        }
+
+        String prefix = cloudFrontDomain + "/";
+        if (!imageUrl.startsWith(prefix)) {
+            return Optional.empty();
+        }
+
+        String key = imageUrl.substring(prefix.length());
+        if (key.isBlank()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(key);
+    }
+
     private String removeTrailingSlash(String value) {
         if (value.endsWith("/")) {
             return value.substring(0, value.length() - 1);
         }
         return value;
+    }
+
+    public record ImageMetadata(
+            String contentType,
+            Long sizeBytes
+    ) {
     }
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageApiDoc.java
@@ -16,13 +16,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "Post", description = "게시물 API")
+@Tag(name = "Image", description = "이미지 업로드 API")
 public interface ImageApiDoc {
 
     @Operation(
             operationId = "uploadPostImage",
-            summary = "게시물 이미지 업로드",
-            description = "게시물 등에 사용될 이미지를 업로드하고 저장된 URL을 반환한다.",
+            summary = "게시물/프로필 이미지 업로드",
+            description = "게시물 및 프로필에 사용될 이미지를 업로드하고 저장된 URL을 반환한다.",
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses(value = {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/ImageController.java
@@ -25,8 +25,7 @@ public class ImageController implements ImageApiDoc {
             Authentication authentication,
             @RequestPart(value = "image", required = false) MultipartFile image
     ) {
-        Long userId = Long.valueOf(authentication.getName());
-        String imageUrl = imageUploadService.upload(userId, image);
+        String imageUrl = imageUploadService.upload(image);
 
         return ResponseEntity.ok(new ImageUploadResponse(imageUrl));
     }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostApiDoc.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/controller/PostApiDoc.java
@@ -299,7 +299,7 @@ public interface PostApiDoc {
                                     * `DUPLICATE_IMAGE_URL`: 중복된 이미지 URL이 존재하는 경우
                                     * `EMPTY_IMAGE_ORDER`: order 필드가 없는 경우
                                     * `EMPTY_THUMBNAIL`: 썸네일이 지정되지 않은 경우
-                                    * `MULTIPLE_THUMBNAILS`: 썸네일이 2개 이상 지정된 경우
+                                    * `MULTIPLE_THUMBNAIL`: 썸네일이 2개 이상 지정된 경우
                             """,
                     content = @Content(
                             mediaType = "application/json",
@@ -422,7 +422,7 @@ public interface PostApiDoc {
                                     * `DUPLICATE_IMAGE_URL`: 중복된 이미지 URL이 존재하는 경우
                                     * `EMPTY_IMAGE_ORDER`: order 필드가 없는 경우
                                     * `EMPTY_THUMBNAIL`: 썸네일이 지정되지 않은 경우
-                                    * `MULTIPLE_THUMBNAILS`: 썸네일이 2개 이상 지정된 경우
+                                    * `MULTIPLE_THUMBNAIL`: 썸네일이 2개 이상 지정된 경우
                             """,
                     content = @Content(
                             mediaType = "application/json",

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/repository/ImageAssetRepository.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/repository/ImageAssetRepository.java
@@ -12,6 +12,8 @@ import java.util.List;
 public interface ImageAssetRepository extends JpaRepository<ImageAsset, Long> {
     List<ImageAsset> findByPost_IdOrderBySortOrderAsc(Long postId);
 
+    boolean existsByUrl(String url);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<ImageAsset> findAllWithLockByUrlInOrderByUrlAsc(List<String> urls);
 }

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/ImageUploadService.java
@@ -3,17 +3,11 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
-import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.exception.ImageErrorCode;
-import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
-import com.hogu.am_i_hogu.domain.user.domain.User;
-import com.hogu.am_i_hogu.domain.user.exception.UserErrorCode;
-import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.Locale;
 import java.util.Set;
 
@@ -32,39 +26,22 @@ public class ImageUploadService {
 
     private final TsidGenerator tsidGenerator;
     private final S3StorageService s3StorageService;
-    private final UserRepository userRepository;
-    private final ImageAssetRepository imageAssetRepository;
 
     /**
-     * 인증 사용자의 게시물 이미지를 S3에 업로드하고, 반환된 CloudFront URL을 image_assets에 저장한다.
+     * 인증 사용자의 이미지를 S3에 업로드하고 반환된 CloudFront URL만 반환한다.
      *
-     * @param userId 이미지를 업로드하는 인증 사용자 id
      * @param image 업로드할 multipart 이미지 파일
      * @return 업로드된 이미지에 접근할 CloudFront URL
-     * @throws CustomException 파일 검증에 실패하거나 활성 사용자 정보를 찾을 수 없는 경우
+     * @throws CustomException 파일 검증에 실패한 경우
      */
-    public String upload(Long userId, MultipartFile image) {
+    public String upload(MultipartFile image) {
         validate(image);
 
-        User uploader = userRepository.findByIdAndIsDeletedFalse(userId)
-                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         long imageId = tsidGenerator.nextId();
         String extension = extractExtension(image.getOriginalFilename());
-        String key = "images/posts/%d.%s".formatted(imageId, extension);
-        String imageUrl = s3StorageService.upload(key, image);
+        String key = "images/%d.%s".formatted(imageId, extension);
 
-        imageAssetRepository.save(ImageAsset.builder()
-                .id(imageId)
-                .uploadedByUser(uploader)
-                .url(imageUrl)
-                .contentType(image.getContentType())
-                .sizeBytes(image.getSize())
-                .isThumbnail(false)
-                .sortOrder(0)
-                .createdAt(LocalDateTime.now())
-                .build());
-
-        return imageUrl;
+        return s3StorageService.upload(key, image);
     }
 
     /**

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostCreateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostCreateService.java
@@ -1,8 +1,8 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
-import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.domain.Category;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
@@ -28,17 +28,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostCreateService {
 
     private final TsidGenerator tsidGenerator;
+    private final S3StorageService s3StorageService;
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
@@ -62,10 +60,7 @@ public class PostCreateService {
         User writer = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         Category category = categoryRepository.findById(request.categories().get(0)).orElseThrow();
-        List<PostImageRequest> images = request.images() == null
-                ? Collections.emptyList()
-                : request.images();
-        List<ImageAsset> imageAssets = findAttachableImageAssets(userId, images);
+        List<PostImageRequest> images = request.images();
 
         // posts.id는 TSID로 생성한다.
         Post post = Post.builder()
@@ -79,14 +74,7 @@ public class PostCreateService {
                 .build();
         Post savedPost = postRepository.save(post);
 
-        for (int index = 0; index < images.size(); index++) {
-            PostImageRequest image = images.get(index);
-            imageAssets.get(index).attachTo(
-                    savedPost,
-                    Boolean.TRUE.equals(image.isThumbnail()),
-                    image.order()
-            );
-        }
+        List<ImageAsset> imageAssets = createImageAssets(writer, savedPost, images, now);
         imageAssetRepository.saveAll(imageAssets);
 
         return new PostCreateResponse(savedPost.getId());
@@ -173,10 +161,13 @@ public class PostCreateService {
      * @param errors 누적할 필드별 오류 목록
      */
     private void validateImages(PostCreateRequest request, List<ErrorResponse.ErrorDetail> errors) {
-        // 이미지는 선택값이라 null과 빈 배열 모두 "이미지 없음"으로 처리한다.
-        List<PostImageRequest> images = request.images() == null
-                ? Collections.emptyList()
-                : request.images();
+        if (request.images() == null) {
+            errors.add(new ErrorResponse.ErrorDetail("images", "EMPTY_IMAGE_URL"));
+            return;
+        }
+
+        // 이미지는 필수 필드지만 빈 배열은 "이미지 없음"으로 처리한다.
+        List<PostImageRequest> images = request.images();
         if (images.size() > 5) {
             errors.add(new ErrorResponse.ErrorDetail("images", "IMAGE_COUNT_EXCEEDED"));
         }
@@ -215,7 +206,7 @@ public class PostCreateService {
 
         // 썸네일이 2개 이상이라면 에러를 반환한다.
         if (thumbnailCount > 1) {
-            errors.add(new ErrorResponse.ErrorDetail("images", "MULTIPLE_THUMBNAILS"));
+            errors.add(new ErrorResponse.ErrorDetail("images", "MULTIPLE_THUMBNAIL"));
         }
     }
 
@@ -237,38 +228,48 @@ public class PostCreateService {
     }
 
     /**
-     * 게시물에 연결할 업로드 image asset을 URL 순서로 잠금 조회한 뒤 요청 순서로 반환한다.
+     * 게시물 이미지 URL의 storage 존재 여부와 중복 저장 여부를 검증한 뒤 이미지 metadata entity를 생성한다.
      *
-     * @param userId 게시물을 작성하는 인증 사용자 id
-     * @param images 게시물에 연결할 이미지 요청 목록
-     * @return 요청 목록 순서와 동일한 연결 가능 image asset 목록
-     * @throws CustomException 업로드되지 않았거나 다른 사용자 또는 다른 게시물에 속한 이미지가 포함된 경우
+     * @param writer 게시물 작성자
+     * @param post 이미지가 연결될 게시물
+     * @param images 게시물 생성 요청에 포함된 이미지 목록
+     * @param now 이미지 metadata 생성 시각
+     * @return 저장할 이미지 metadata entity 목록
+     * @throws CustomException 이미지 URL이 storage에 없거나 이미 다른 게시물 이미지로 저장된 경우
      */
-    private List<ImageAsset> findAttachableImageAssets(Long userId, List<PostImageRequest> images) {
+    private List<ImageAsset> createImageAssets(
+            User writer,
+            Post post,
+            List<PostImageRequest> images,
+            LocalDateTime now
+    ) {
         if (images.isEmpty()) {
             return Collections.emptyList();
         }
 
         List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
         List<ImageAsset> imageAssets = new ArrayList<>();
-        List<String> sortedImageUrls = images.stream()
-                .map(PostImageRequest::imageUrl)
-                .sorted()
-                .toList();
-        Map<String, ImageAsset> imageAssetsByUrl = imageAssetRepository
-                .findAllWithLockByUrlInOrderByUrlAsc(sortedImageUrls)
-                .stream()
-                .collect(Collectors.toMap(ImageAsset::getUrl, Function.identity()));
-
         for (PostImageRequest image : images) {
-            ImageAsset imageAsset = imageAssetsByUrl.get(image.imageUrl());
-            if (imageAsset == null
-                    || !Objects.equals(imageAsset.getUploadedByUser().getId(), userId)
-                    || imageAsset.getPost() != null) {
+            Optional<S3StorageService.ImageMetadata> metadata = s3StorageService.findImageMetadata(image.imageUrl());
+            if (metadata.isEmpty() || metadata.get().contentType() == null || metadata.get().contentType().isBlank()) {
                 errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
                 continue;
             }
-            imageAssets.add(imageAsset);
+            if (imageAssetRepository.existsByUrl(image.imageUrl())) {
+                errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
+                continue;
+            }
+            imageAssets.add(ImageAsset.builder()
+                    .id(tsidGenerator.nextId())
+                    .uploadedByUser(writer)
+                    .post(post)
+                    .url(image.imageUrl())
+                    .contentType(metadata.get().contentType())
+                    .sizeBytes(metadata.get().sizeBytes())
+                    .isThumbnail(Boolean.TRUE.equals(image.isThumbnail()))
+                    .sortOrder(image.order())
+                    .createdAt(now)
+                    .build());
         }
 
         if (!errors.isEmpty()) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateService.java
@@ -3,6 +3,8 @@ package com.hogu.am_i_hogu.domain.post.service;
 import com.hogu.am_i_hogu.common.exception.CommonErrorCode;
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
+import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.domain.Category;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
@@ -13,6 +15,7 @@ import com.hogu.am_i_hogu.domain.post.exception.PostErrorCode;
 import com.hogu.am_i_hogu.domain.post.repository.CategoryRepository;
 import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
+import com.hogu.am_i_hogu.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,15 +27,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class PostUpdateService {
+    private final TsidGenerator tsidGenerator;
+    private final S3StorageService s3StorageService;
     private final CategoryRepository categoryRepository;
     private final PostRepository postRepository;
     private final ImageAssetRepository imageAssetRepository;
@@ -75,21 +78,15 @@ public class PostUpdateService {
 
         post.update(request.title(), category, request.content(), now);
 
-        // 수정된 이미지가 있다면 기존 연결을 해제하고 업로드된 image asset을 요청 순서대로 다시 연결한다.
+        // 수정된 이미지가 있다면 기존 이미지 row를 삭제하고 요청 이미지를 새 image asset으로 저장한다.
         if (request.images() != null) {
-            List<ImageAsset> imageAssets = findAttachableImageAssets(postId, userId, request.images());
             List<ImageAsset> previousImageAssets = imageAssetRepository.findByPost_IdOrderBySortOrderAsc(postId);
-            previousImageAssets.forEach(ImageAsset::detach);
+            Set<String> previousImageUrls = previousImageAssets.stream()
+                    .map(ImageAsset::getUrl)
+                    .collect(Collectors.toSet());
+            List<ImageAsset> imageAssets = createImageAssets(post.getWriter(), post, request.images(), previousImageUrls, now);
+            imageAssetRepository.deleteAll(previousImageAssets);
             imageAssetRepository.flush();
-
-            for (int index = 0; index < request.images().size(); index++) {
-                PostImageRequest image = request.images().get(index);
-                imageAssets.get(index).attachTo(
-                        post,
-                        Boolean.TRUE.equals(image.isThumbnail()),
-                        image.order()
-                );
-            }
             imageAssetRepository.saveAll(imageAssets);
         }
 
@@ -235,7 +232,7 @@ public class PostUpdateService {
 
         // 썸네일이 2개 이상이라면 에러를 반환한다.
         if (thumbnailCount > 1) {
-            errors.add(new ErrorResponse.ErrorDetail("images", "MULTIPLE_THUMBNAILS"));
+            errors.add(new ErrorResponse.ErrorDetail("images", "MULTIPLE_THUMBNAIL"));
         }
     }
 
@@ -256,19 +253,12 @@ public class PostUpdateService {
         }
     }
 
-    /**
-     * 게시물에 연결할 업로드 image asset을 URL 순서로 잠금 조회한 뒤 요청 순서로 반환한다.
-     *
-     * @param postId 이미지를 수정할 게시물 id
-     * @param userId 수정을 요청하는 인증 사용자 id
-     * @param images 게시물에 연결할 이미지 요청 목록
-     * @return 요청 목록 순서와 동일한 연결 가능 image asset 목록
-     * @throws CustomException 업로드되지 않았거나 다른 사용자 또는 다른 게시물에 속한 이미지가 포함된 경우
-     */
-    private List<ImageAsset> findAttachableImageAssets(
-            Long postId,
-            Long userId,
-            List<PostImageRequest> images
+    private List<ImageAsset> createImageAssets(
+            User writer,
+            Post post,
+            List<PostImageRequest> images,
+            Set<String> previousImageUrls,
+            LocalDateTime now
     ) {
         if (images.isEmpty()) {
             return Collections.emptyList();
@@ -276,24 +266,27 @@ public class PostUpdateService {
 
         List<ErrorResponse.ErrorDetail> errors = new ArrayList<>();
         List<ImageAsset> imageAssets = new ArrayList<>();
-        List<String> sortedImageUrls = images.stream()
-                .map(PostImageRequest::imageUrl)
-                .sorted()
-                .toList();
-        Map<String, ImageAsset> imageAssetsByUrl = imageAssetRepository
-                .findAllWithLockByUrlInOrderByUrlAsc(sortedImageUrls)
-                .stream()
-                .collect(Collectors.toMap(ImageAsset::getUrl, Function.identity()));
-
         for (PostImageRequest image : images) {
-            ImageAsset imageAsset = imageAssetsByUrl.get(image.imageUrl());
-            if (imageAsset == null
-                    || !Objects.equals(imageAsset.getUploadedByUser().getId(), userId)
-                    || (imageAsset.getPost() != null && !Objects.equals(imageAsset.getPost().getId(), postId))) {
+            Optional<S3StorageService.ImageMetadata> metadata = s3StorageService.findImageMetadata(image.imageUrl());
+            if (metadata.isEmpty() || metadata.get().contentType() == null || metadata.get().contentType().isBlank()) {
                 errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
                 continue;
             }
-            imageAssets.add(imageAsset);
+            if (!previousImageUrls.contains(image.imageUrl()) && imageAssetRepository.existsByUrl(image.imageUrl())) {
+                errors.add(new ErrorResponse.ErrorDetail("images", "INVALID_IMAGE_URL"));
+                continue;
+            }
+            imageAssets.add(ImageAsset.builder()
+                    .id(tsidGenerator.nextId())
+                    .uploadedByUser(writer)
+                    .post(post)
+                    .url(image.imageUrl())
+                    .contentType(metadata.get().contentType())
+                    .sizeBytes(metadata.get().sizeBytes())
+                    .isThumbnail(Boolean.TRUE.equals(image.isThumbnail()))
+                    .sortOrder(image.order())
+                    .createdAt(now)
+                    .build());
         }
 
         if (!errors.isEmpty()) {

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/ProfileUpdateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/ProfileUpdateService.java
@@ -165,7 +165,6 @@ public class ProfileUpdateService {
             return;
         }
 
-        // TODO: S3 연결 후 이미지 url 유효성 검증 추가
         // url 형식이 올바르지 않은 경우
         if (!isValidImageUrl(profileImageUrl)) {
             errors.add(new ErrorResponse.ErrorDetail(

--- a/src/main/java/com/hogu/am_i_hogu/domain/user/service/ProfileUpdateService.java
+++ b/src/main/java/com/hogu/am_i_hogu/domain/user/service/ProfileUpdateService.java
@@ -2,6 +2,7 @@ package com.hogu.am_i_hogu.domain.user.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
 import com.hogu.am_i_hogu.common.exception.ErrorResponse;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import com.hogu.am_i_hogu.domain.user.dto.request.UpdateProfileRequest;
 import com.hogu.am_i_hogu.domain.user.dto.response.UpdateProfileResponse;
@@ -23,9 +24,11 @@ import static com.hogu.am_i_hogu.domain.user.service.ProfileUpdateService.Profil
 public class ProfileUpdateService {
 
     private final UserRepository userRepository;
+    private final S3StorageService s3StorageService;
 
-    public ProfileUpdateService(UserRepository userRepository) {
+    public ProfileUpdateService(UserRepository userRepository, S3StorageService s3StorageService) {
         this.userRepository = userRepository;
+        this.s3StorageService = s3StorageService;
     }
 
     public enum ProfileImageRequestType {
@@ -165,6 +168,14 @@ public class ProfileUpdateService {
         // TODO: S3 연결 후 이미지 url 유효성 검증 추가
         // url 형식이 올바르지 않은 경우
         if (!isValidImageUrl(profileImageUrl)) {
+            errors.add(new ErrorResponse.ErrorDetail(
+                    "images",
+                    "INVALID_IMAGE_URL"
+            ));
+            return;
+        }
+
+        if (s3StorageService.findImageMetadata(profileImageUrl).isEmpty()) {
             errors.add(new ErrorResponse.ErrorDetail(
                     "images",
                     "INVALID_IMAGE_URL"

--- a/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/common/storage/S3StorageServiceTest.java
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class S3StorageServiceTest {
 
@@ -39,5 +42,43 @@ class S3StorageServiceTest {
                 any(InputStream.class),
                 any(ObjectMetadata.class)
         );
+    }
+
+    @Test
+    void findImageMetadataReturnsMetadataForCloudFrontUrl() {
+        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        S3StorageService s3StorageService = new S3StorageService(
+                amazonS3,
+                "am-i-hogu-images",
+                "https://d111111abcdef8.cloudfront.net"
+        );
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/jpeg");
+        metadata.setContentLength(123L);
+        when(amazonS3.getObjectMetadata("am-i-hogu-images", "images/1.jpg"))
+                .thenReturn(metadata);
+
+        Optional<S3StorageService.ImageMetadata> result =
+                s3StorageService.findImageMetadata("https://d111111abcdef8.cloudfront.net/images/1.jpg");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().contentType()).isEqualTo("image/jpeg");
+        assertThat(result.get().sizeBytes()).isEqualTo(123L);
+    }
+
+    @Test
+    void findImageMetadataReturnsEmptyForUrlOutsideCloudFrontDomain() {
+        AmazonS3 amazonS3 = mock(AmazonS3.class);
+        S3StorageService s3StorageService = new S3StorageService(
+                amazonS3,
+                "am-i-hogu-images",
+                "https://d111111abcdef8.cloudfront.net"
+        );
+
+        Optional<S3StorageService.ImageMetadata> result =
+                s3StorageService.findImageMetadata("https://external.example.com/images/1.jpg");
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(amazonS3);
     }
 }

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/ImageControllerTest.java
@@ -7,13 +7,10 @@ import com.hogu.am_i_hogu.common.security.JwtProvider;
 import com.hogu.am_i_hogu.common.security.SecurityConfig;
 import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
-import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
-import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.service.ImageUploadService;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -24,14 +21,12 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -60,27 +55,23 @@ class ImageControllerTest {
     @MockitoBean
     private S3StorageService s3StorageService;
 
-    @MockitoBean
-    private ImageAssetRepository imageAssetRepository;
-
-    // 정상 케이스: jpg 이미지 파일을 업로드하면 200 OK와 CloudFront imageUrl을 반환한다.
+    // 정상 케이스: jpg 이미지 파일을 S3에 업로드하면 DB 저장 없이 200 OK와 CloudFront imageUrl을 반환한다.
     @Test
     void uploadImageReturnsS3ImageUrl() throws Exception {
-        User uploader = mock(User.class);
         when(jwtProvider.validateAccessToken("valid-token"))
                 .thenReturn(JwtProvider.TokenValidationResult.VALID);
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(uploader));
+                .thenReturn(Optional.of(new User(1L, "hogu", false, LocalDateTime.now())));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
                 null,
                 Collections.emptyList()
         ));
-        when(s3StorageService.upload(org.mockito.ArgumentMatchers.startsWith("images/posts/"), any()))
-                .thenReturn("https://d111111abcdef8.cloudfront.net/images/posts/1.jpg");
+        when(s3StorageService.upload(org.mockito.ArgumentMatchers.startsWith("images/"), any()))
+                .thenReturn("https://d111111abcdef8.cloudfront.net/images/1.jpg");
 
         MockMultipartFile image = new MockMultipartFile(
                 "image",
@@ -93,16 +84,7 @@ class ImageControllerTest {
                         .file(image)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.imageUrl", startsWith("https://d111111abcdef8.cloudfront.net/images/posts/")));
-
-        ArgumentCaptor<ImageAsset> imageAssetCaptor = ArgumentCaptor.forClass(ImageAsset.class);
-        verify(imageAssetRepository).save(imageAssetCaptor.capture());
-        ImageAsset imageAsset = imageAssetCaptor.getValue();
-        assertThat(imageAsset.getUploadedByUser()).isSameAs(uploader);
-        assertThat(imageAsset.getPost()).isNull();
-        assertThat(imageAsset.getUrl()).isEqualTo("https://d111111abcdef8.cloudfront.net/images/posts/1.jpg");
-        assertThat(imageAsset.getContentType()).isEqualTo(MediaType.IMAGE_JPEG_VALUE);
-        assertThat(imageAsset.getSizeBytes()).isEqualTo((long) "image-content".getBytes().length);
+                .andExpect(jsonPath("$.imageUrl", startsWith("https://d111111abcdef8.cloudfront.net/images/")));
     }
 
     // 실패 케이스: multipart 요청에 image 파일이 없으면 400 Bad Request와 EMPTY_IMAGE_FILE을 반환한다.
@@ -113,7 +95,7 @@ class ImageControllerTest {
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(mock(User.class)));
+                .thenReturn(Optional.of(new User(1L, "hogu", false, LocalDateTime.now())));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
@@ -135,7 +117,7 @@ class ImageControllerTest {
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(mock(User.class)));
+                .thenReturn(Optional.of(new User(1L, "hogu", false, LocalDateTime.now())));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
@@ -165,7 +147,7 @@ class ImageControllerTest {
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(mock(User.class)));
+                .thenReturn(Optional.of(new User(1L, "hogu", false, LocalDateTime.now())));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",
@@ -195,7 +177,7 @@ class ImageControllerTest {
         when(jwtProvider.getSubjectAsLong("valid-token"))
                 .thenReturn(1L);
         when(userRepository.findByIdAndIsDeletedFalse(1L))
-                .thenReturn(Optional.of(mock(User.class)));
+                .thenReturn(Optional.of(new User(1L, "hogu", false, LocalDateTime.now())));
         when(jwtProvider.getAuthentication("valid-token"))
                 .thenReturn(new UsernamePasswordAuthenticationToken(
                         "1",

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/controller/PostControllerTest.java
@@ -1,6 +1,7 @@
 package com.hogu.am_i_hogu.domain.post.controller;
 
 import com.hogu.am_i_hogu.common.security.JwtProvider;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -66,6 +68,9 @@ class PostControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private S3StorageService s3StorageService;
 
     @BeforeEach
     void setUp() {
@@ -297,8 +302,7 @@ class PostControllerTest {
     @Test
     void createPostReturnsPostIdAndPersistsPost() throws Exception {
         stubAuthenticatedUser();
-        LocalDateTime now = LocalDateTime.now();
-        insertUploadedImage(1001L, "http://localhost/temporary/images/1/post-image.jpg", now);
+        stubImageMetadata("http://localhost/temporary/images/1/post-image.jpg", "image/jpeg", 10L);
 
         String requestBody = """
                 {
@@ -337,7 +341,7 @@ class PostControllerTest {
         assertThat(imageCount).isEqualTo(1);
     }
 
-    // 실패 케이스: 이미지 업로드 API로 생성되지 않은 URL은 게시물 이미지로 연결할 수 없다.
+    // 실패 케이스: S3에 존재하지 않는 URL은 게시물 이미지로 저장할 수 없다.
     @Test
     void createPostRejectsImageThatWasNotUploaded() throws Exception {
         stubAuthenticatedUser();
@@ -367,7 +371,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.errors[0].code").value("INVALID_IMAGE_URL"));
     }
 
-    // 실패 케이스: 다른 사용자가 업로드한 이미지는 게시물 이미지로 연결할 수 없다.
+    // 실패 케이스: 이미 image_assets에 저장된 다른 사용자의 URL은 새 게시물 이미지로 저장할 수 없다.
     @Test
     void createPostRejectsImageUploadedByAnotherUser() throws Exception {
         stubAuthenticatedUser();
@@ -375,6 +379,7 @@ class PostControllerTest {
         Long otherUserId = 2L;
         insertUser(otherUserId, "other-hogu", now);
         insertUploadedImage(1001L, otherUserId, "https://cdn.example.com/another-user.jpg", now);
+        stubImageMetadata("https://cdn.example.com/another-user.jpg", "image/jpeg", 10L);
 
         String requestBody = """
                 {
@@ -408,6 +413,7 @@ class PostControllerTest {
         LocalDateTime now = LocalDateTime.now();
         insertPost(1234L, TEST_USER_ID, "USED_TRADE", "기존 글", "기존 본문", false, now);
         insertImage(1001L, 1234L, "https://cdn.example.com/attached.jpg", true, 0, now);
+        stubImageMetadata("https://cdn.example.com/attached.jpg", "image/jpeg", 10L);
 
         String requestBody = """
                 {
@@ -478,6 +484,29 @@ class PostControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("EMPTY_REQUEST_BODY"));
+    }
+
+    // 실패 케이스: 생성 요청에서 images 필드가 누락되면 명세에 따라 필드 오류를 반환한다.
+    @Test
+    void createPostRejectsMissingImagesField() throws Exception {
+        stubAuthenticatedUser();
+
+        String requestBody = """
+                {
+                  "title": "제목입니다",
+                  "categories": ["USED_TRADE"],
+                  "content": "본문입니다"
+                }
+                """;
+
+        mockMvc.perform(post("/api/posts")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer valid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+                .andExpect(jsonPath("$.errors[0].field").value("images"))
+                .andExpect(jsonPath("$.errors[0].code").value("EMPTY_IMAGE_URL"));
     }
 
     // 실패 케이스: 필수 필드가 비어 있으면 400 Bad Request와 필드별 오류 코드를 반환한다.
@@ -603,7 +632,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.errors[0].code").value("INVALID_CATEGORIES"));
     }
 
-    // 실패 케이스: 썸네일이 2개 이상이면 단일 썸네일 정책에 따라 MULTIPLE_THUMBNAILS를 반환한다.
+    // 실패 케이스: 썸네일이 2개 이상이면 단일 썸네일 정책에 따라 MULTIPLE_THUMBNAIL을 반환한다.
     @Test
     void createPostRejectsMultipleThumbnails() throws Exception {
         stubAuthenticatedUser();
@@ -627,7 +656,7 @@ class PostControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
                 .andExpect(jsonPath("$.errors[0].field").value("images"))
-                .andExpect(jsonPath("$.errors[0].code").value("MULTIPLE_THUMBNAILS"));
+                .andExpect(jsonPath("$.errors[0].code").value("MULTIPLE_THUMBNAIL"));
     }
 
     // 실패 케이스: images 배열 안에 null이 있으면 NullPointerException 대신 필드 오류를 반환한다.
@@ -664,8 +693,8 @@ class PostControllerTest {
         insertPost(postId, TEST_USER_ID, "USED_TRADE", "기존 제목", "기존 본문", false, now);
         insertImage(1001L, postId, "https://example.com/old-thumbnail.jpg", true, 0, now);
         insertImage(1002L, postId, "https://example.com/old-image.jpg", false, 1, now);
-        insertUploadedImage(1003L, "https://example.com/new-thumbnail.png", now);
-        insertUploadedImage(1004L, "https://example.com/new-image.webp", now);
+        stubImageMetadata("https://example.com/new-thumbnail.png", "image/png", 10L);
+        stubImageMetadata("https://example.com/new-image.webp", "image/webp", 10L);
 
         String requestBody = """
                 {
@@ -716,8 +745,8 @@ class PostControllerTest {
                 postId,
                 "https://example.com/old-%"
         );
-        Integer detachedOldImageCount = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM image_assets WHERE post_id IS NULL AND url LIKE ?",
+        Integer deletedOldImageCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM image_assets WHERE url LIKE ?",
                 Integer.class,
                 "https://example.com/old-%"
         );
@@ -732,7 +761,7 @@ class PostControllerTest {
         assertThat(updatedContent).isEqualTo("수정 본문");
         assertThat(imageCount).isEqualTo(2);
         assertThat(oldImageCount).isZero();
-        assertThat(detachedOldImageCount).isEqualTo(2);
+        assertThat(deletedOldImageCount).isZero();
         assertThat(thumbnailUrl).isEqualTo("https://example.com/new-thumbnail.png");
     }
 
@@ -913,7 +942,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.errors[0].code").value("EMPTY_IMAGE_ORDER"));
     }
 
-    // 실패 케이스: 수정 요청의 썸네일이 2개 이상이면 MULTIPLE_THUMBNAILS를 반환한다.
+    // 실패 케이스: 수정 요청의 썸네일이 2개 이상이면 MULTIPLE_THUMBNAIL을 반환한다.
     @Test
     void updatePostRejectsMultipleThumbnails() throws Exception {
         stubAuthenticatedUser();
@@ -938,7 +967,7 @@ class PostControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
                 .andExpect(jsonPath("$.errors[0].field").value("images"))
-                .andExpect(jsonPath("$.errors[0].code").value("MULTIPLE_THUMBNAILS"));
+                .andExpect(jsonPath("$.errors[0].code").value("MULTIPLE_THUMBNAIL"));
     }
 
     // 정상 케이스: 비회원도 게시글 상세 정보를 조회할 수 있다.
@@ -1776,6 +1805,11 @@ class PostControllerTest {
                 0,
                 now
         );
+    }
+
+    private void stubImageMetadata(String imageUrl, String contentType, Long sizeBytes) {
+        when(s3StorageService.findImageMetadata(imageUrl))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata(contentType, sizeBytes)));
     }
 
     private void insertPostVote(Long userId, Long postId, String myVote, LocalDateTime now) {

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostCreateServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostCreateServiceTest.java
@@ -1,5 +1,6 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.domain.Category;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
@@ -12,6 +13,7 @@ import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import com.hogu.am_i_hogu.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +21,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,32 +33,32 @@ class PostCreateServiceTest {
     private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
     private final PostRepository postRepository = mock(PostRepository.class);
     private final ImageAssetRepository imageAssetRepository = mock(ImageAssetRepository.class);
+    private final S3StorageService s3StorageService = mock(S3StorageService.class);
     private final PostCreateService postCreateService = new PostCreateService(
             tsidGenerator,
+            s3StorageService,
             userRepository,
             categoryRepository,
             postRepository,
             imageAssetRepository
     );
 
-    // 정상 케이스: 게시물 생성 시 이미지 자산은 URL 순서로 잠금 조회하고 요청 순서대로 게시물에 연결한다.
+    // 정상 케이스: 게시물 생성 시 S3에 존재하는 이미지 URL만 image_assets에 새로 저장한다.
     @Test
-    void createLocksUploadedImagesInStableOrderAndAttachesInRequestOrder() {
+    void createStoresImageAssetsFromS3MetadataInRequestOrder() {
         LocalDateTime now = LocalDateTime.now();
         User writer = new User(1L, "hogu", false, now);
         Category category = mock(Category.class);
-        ImageAsset firstByUrl = uploadedImage(101L, writer, "https://cdn.example.com/a.jpg", now);
-        ImageAsset secondByUrl = uploadedImage(102L, writer, "https://cdn.example.com/b.jpg", now);
 
         when(categoryRepository.existsById("USED_TRADE")).thenReturn(true);
         when(userRepository.findById(1L)).thenReturn(Optional.of(writer));
         when(categoryRepository.findById("USED_TRADE")).thenReturn(Optional.of(category));
-        when(tsidGenerator.nextId()).thenReturn(11L);
+        when(tsidGenerator.nextId()).thenReturn(11L, 101L, 102L);
         when(postRepository.save(any(Post.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(imageAssetRepository.findAllWithLockByUrlInOrderByUrlAsc(List.of(
-                "https://cdn.example.com/a.jpg",
-                "https://cdn.example.com/b.jpg"
-        ))).thenReturn(List.of(firstByUrl, secondByUrl));
+        when(s3StorageService.findImageMetadata("https://cdn.example.com/b.jpg"))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata("image/jpeg", 20L)));
+        when(s3StorageService.findImageMetadata("https://cdn.example.com/a.jpg"))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata("image/jpeg", 10L)));
 
         PostCreateRequest request = new PostCreateRequest(
                 "title",
@@ -69,28 +72,24 @@ class PostCreateServiceTest {
 
         postCreateService.create(1L, request);
 
-        verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
-                "https://cdn.example.com/a.jpg",
-                "https://cdn.example.com/b.jpg"
-        ));
-        assertThat(secondByUrl.getPost().getId()).isEqualTo(11L);
-        assertThat(secondByUrl.isThumbnail()).isTrue();
-        assertThat(secondByUrl.getSortOrder()).isZero();
-        assertThat(firstByUrl.getPost().getId()).isEqualTo(11L);
-        assertThat(firstByUrl.isThumbnail()).isFalse();
-        assertThat(firstByUrl.getSortOrder()).isEqualTo(1);
-    }
+        verify(imageAssetRepository, never()).findAllWithLockByUrlInOrderByUrlAsc(any());
+        ArgumentCaptor<List<ImageAsset>> imageAssetsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(imageAssetRepository).saveAll(imageAssetsCaptor.capture());
 
-    private ImageAsset uploadedImage(Long id, User uploader, String url, LocalDateTime now) {
-        return ImageAsset.builder()
-                .id(id)
-                .uploadedByUser(uploader)
-                .url(url)
-                .contentType("image/jpeg")
-                .sizeBytes(10L)
-                .isThumbnail(false)
-                .sortOrder(0)
-                .createdAt(now)
-                .build();
+        List<ImageAsset> imageAssets = imageAssetsCaptor.getValue();
+        assertThat(imageAssets).hasSize(2);
+        assertThat(imageAssets.get(0).getId()).isEqualTo(101L);
+        assertThat(imageAssets.get(0).getUploadedByUser()).isSameAs(writer);
+        assertThat(imageAssets.get(0).getPost().getId()).isEqualTo(11L);
+        assertThat(imageAssets.get(0).getUrl()).isEqualTo("https://cdn.example.com/b.jpg");
+        assertThat(imageAssets.get(0).getContentType()).isEqualTo("image/jpeg");
+        assertThat(imageAssets.get(0).getSizeBytes()).isEqualTo(20L);
+        assertThat(imageAssets.get(0).isThumbnail()).isTrue();
+        assertThat(imageAssets.get(0).getSortOrder()).isZero();
+        assertThat(imageAssets.get(1).getId()).isEqualTo(102L);
+        assertThat(imageAssets.get(1).getUrl()).isEqualTo("https://cdn.example.com/a.jpg");
+        assertThat(imageAssets.get(1).getSizeBytes()).isEqualTo(10L);
+        assertThat(imageAssets.get(1).isThumbnail()).isFalse();
+        assertThat(imageAssets.get(1).getSortOrder()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/post/service/PostUpdateServiceTest.java
@@ -1,6 +1,8 @@
 package com.hogu.am_i_hogu.domain.post.service;
 
 import com.hogu.am_i_hogu.common.exception.CustomException;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
+import com.hogu.am_i_hogu.common.util.TsidGenerator;
 import com.hogu.am_i_hogu.domain.post.domain.Category;
 import com.hogu.am_i_hogu.domain.post.domain.ImageAsset;
 import com.hogu.am_i_hogu.domain.post.domain.Post;
@@ -12,6 +14,7 @@ import com.hogu.am_i_hogu.domain.post.repository.ImageAssetRepository;
 import com.hogu.am_i_hogu.domain.post.repository.PostRepository;
 import com.hogu.am_i_hogu.domain.user.domain.User;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 
 import java.time.LocalDateTime;
@@ -32,7 +35,11 @@ class PostUpdateServiceTest {
     private final CategoryRepository categoryRepository = mock(CategoryRepository.class);
     private final PostRepository postRepository = mock(PostRepository.class);
     private final ImageAssetRepository imageAssetRepository = mock(ImageAssetRepository.class);
+    private final TsidGenerator tsidGenerator = mock(TsidGenerator.class);
+    private final S3StorageService s3StorageService = mock(S3StorageService.class);
     private final PostUpdateService postUpdateService = new PostUpdateService(
+            tsidGenerator,
+            s3StorageService,
             categoryRepository,
             postRepository,
             imageAssetRepository
@@ -115,9 +122,9 @@ class PostUpdateServiceTest {
         verifyNoInteractions(imageAssetRepository);
     }
 
-    // 정상 케이스: 게시물 수정 시 이미지 자산은 URL 순서로 잠금 조회하고 요청 순서대로 다시 연결한다.
+    // 정상 케이스: 게시물 수정 시 기존 이미지를 삭제하고 S3에 존재하는 요청 이미지를 새로 저장한다.
     @Test
-    void updateLocksUploadedImagesInStableOrderAndAttachesInRequestOrder() {
+    void updateReplacesImagesWithNewImageAssetsFromS3Metadata() {
         LocalDateTime now = LocalDateTime.now();
         User writer = new User(1L, "hogu", false, now);
         Post post = Post.builder()
@@ -129,15 +136,15 @@ class PostUpdateServiceTest {
                 .createdAt(now)
                 .updatedAt(now)
                 .build();
-        ImageAsset firstByUrl = uploadedImage(101L, writer, "https://cdn.example.com/a.jpg", now);
-        ImageAsset secondByUrl = uploadedImage(102L, writer, "https://cdn.example.com/b.jpg", now);
+        ImageAsset oldImage = uploadedImage(201L, writer, "https://cdn.example.com/old.jpg", now);
 
         when(postRepository.findByIdWithLock(11L)).thenReturn(Optional.of(post));
-        when(imageAssetRepository.findAllWithLockByUrlInOrderByUrlAsc(List.of(
-                "https://cdn.example.com/a.jpg",
-                "https://cdn.example.com/b.jpg"
-        ))).thenReturn(List.of(firstByUrl, secondByUrl));
-        when(imageAssetRepository.findByPost_IdOrderBySortOrderAsc(11L)).thenReturn(List.of());
+        when(imageAssetRepository.findByPost_IdOrderBySortOrderAsc(11L)).thenReturn(List.of(oldImage));
+        when(tsidGenerator.nextId()).thenReturn(101L, 102L);
+        when(s3StorageService.findImageMetadata("https://cdn.example.com/b.jpg"))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata("image/jpeg", 20L)));
+        when(s3StorageService.findImageMetadata("https://cdn.example.com/a.jpg"))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata("image/jpeg", 10L)));
 
         PostUpdateRequest request = new PostUpdateRequest(
                 null,
@@ -153,16 +160,24 @@ class PostUpdateServiceTest {
 
         InOrder inOrder = inOrder(postRepository, imageAssetRepository);
         inOrder.verify(postRepository).findByIdWithLock(11L);
-        inOrder.verify(imageAssetRepository).findAllWithLockByUrlInOrderByUrlAsc(List.of(
-                "https://cdn.example.com/a.jpg",
-                "https://cdn.example.com/b.jpg"
-        ));
-        assertThat(secondByUrl.getPost()).isSameAs(post);
-        assertThat(secondByUrl.isThumbnail()).isTrue();
-        assertThat(secondByUrl.getSortOrder()).isZero();
-        assertThat(firstByUrl.getPost()).isSameAs(post);
-        assertThat(firstByUrl.isThumbnail()).isFalse();
-        assertThat(firstByUrl.getSortOrder()).isEqualTo(1);
+        inOrder.verify(imageAssetRepository).findByPost_IdOrderBySortOrderAsc(11L);
+        inOrder.verify(imageAssetRepository).deleteAll(List.of(oldImage));
+        inOrder.verify(imageAssetRepository).flush();
+
+        ArgumentCaptor<List<ImageAsset>> imageAssetsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(imageAssetRepository).saveAll(imageAssetsCaptor.capture());
+        List<ImageAsset> imageAssets = imageAssetsCaptor.getValue();
+        assertThat(imageAssets).hasSize(2);
+        assertThat(imageAssets.get(0).getId()).isEqualTo(101L);
+        assertThat(imageAssets.get(0).getPost()).isSameAs(post);
+        assertThat(imageAssets.get(0).getUrl()).isEqualTo("https://cdn.example.com/b.jpg");
+        assertThat(imageAssets.get(0).isThumbnail()).isTrue();
+        assertThat(imageAssets.get(0).getSortOrder()).isZero();
+        assertThat(imageAssets.get(1).getId()).isEqualTo(102L);
+        assertThat(imageAssets.get(1).getPost()).isSameAs(post);
+        assertThat(imageAssets.get(1).getUrl()).isEqualTo("https://cdn.example.com/a.jpg");
+        assertThat(imageAssets.get(1).isThumbnail()).isFalse();
+        assertThat(imageAssets.get(1).getSortOrder()).isEqualTo(1);
     }
 
     private ImageAsset uploadedImage(Long id, User uploader, String url, LocalDateTime now) {

--- a/src/test/java/com/hogu/am_i_hogu/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/hogu/am_i_hogu/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package com.hogu.am_i_hogu.domain.user.controller;
 
 import com.hogu.am_i_hogu.common.security.JwtProvider;
+import com.hogu.am_i_hogu.common.storage.S3StorageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ import com.jayway.jsonpath.JsonPath;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.startsWith;
@@ -60,6 +62,9 @@ public class UserControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private S3StorageService s3StorageService;
 
     @BeforeEach
     void setUp() {
@@ -127,6 +132,7 @@ public class UserControllerTest {
     void updateProfileReturns200WhenProfileImageIsUpdated() throws Exception {
         stubAuthenticatedUser();
         insertUser(1L, "nickname", null);
+        stubImageMetadata("http://localhost:8080/temporary/images/1/profile-image.jpg");
 
         String requestBody = """
                 {
@@ -168,6 +174,7 @@ public class UserControllerTest {
     void updateProfileReturns200WhenNicknameAndProfileImageAreUpdated() throws Exception {
         stubAuthenticatedUser();
         insertUser(1L, "oldNickname", null);
+        stubImageMetadata("http://localhost:8080/temporary/images/1/profile-image.jpg");
 
         String requestBody = """
                 {
@@ -1546,5 +1553,10 @@ public class UserControllerTest {
                 now,
                 votedPostCount
         );
+    }
+
+    private void stubImageMetadata(String imageUrl) {
+        when(s3StorageService.findImageMetadata(imageUrl))
+                .thenReturn(Optional.of(new S3StorageService.ImageMetadata("image/jpeg", 10L)));
     }
 }


### PR DESCRIPTION
## 📋 변경 사항

<!-- 무엇을 왜 변경했는지 간단히 설명해주세요 -->
이미지 업로드 API가 `image_assets`를 직접 저장하지 않고 URL만 반환하도록 변경했습니다.

기존에는 이미지 업로드 시점에 DB row가 생성되는 흐름이었지만, 실제 저장을 게시물/프로필 API로 옮겼습니다.

- `POST /api/images`
  - S3에 이미지를 업로드하고 URL만 반환
  - `image_assets` 저장 제거
- S3 이미지 metadata 조회 기능 추가
  - 이미지 URL에서 S3 key를 추출해 object metadata 조회
  - 존재하지 않는 URL은 게시물/프로필 저장 시 invalid 처리
- 게시물 생성/수정 이미지 저장 흐름 변경
  - 요청 이미지 URL을 S3 metadata로 검증
  - 검증된 URL만 `image_assets`로 저장
  - 이미 저장된 이미지 URL 재사용 방지
  - 게시물 수정 시 `images` 필드가 없으면 기존 이미지 유지, 빈 배열이면 삭제
- 프로필 이미지 저장 흐름 변경
  - `profileImageUrl`은 S3 metadata 검증 후 `users.profile_image_url`에만 저장
  - 프로필 이미지는 `image_assets`와 연결하지 않음
- 관련 테스트 및 REST Docs 기대값 수정

## 🏷️ PR 유형

- [x] 🚀 feat: 새로운 기능 추가
- [ ] 🐛 fix: 버그 수정
- [x] ♻️ refactor: 코드 리팩토링
- [x] 📝 docs: 문서 수정
- [x] ✅ test: 테스트 코드 추가/수정
- [ ] 🔧 chore: 빌드/패키지 매니저 수정

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션 준수
- [x] 로컬 테스트 완료
- [ ] 테스트 해당 없음 (문서/설정 변경 등)
- [x] 코드 리뷰 준비 완료
